### PR TITLE
ZMS-187: Rewrite addMessage, moveMessage to async/await

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -615,7 +615,7 @@ class MessageHandler {
                             idate: messageData.idate,
                             thread: messageData.thread
                         },
-                        async () => {
+                        () => {
                             // added Entries
                             this.notifier.fire(mailboxData.user);
 
@@ -663,12 +663,7 @@ class MessageHandler {
                             });
 
                             // do not use more suitable finally as it is not supported in Node v8
-                            try {
-                                await processAudits();
-                                resolve(cleanupRes);
-                            } catch {
-                                resolve(cleanupRes);
-                            }
+                            processAudits().then(resolve(cleanupRes)).catch(resolve(cleanupRes));
                         }
                     );
                 });

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1378,7 +1378,7 @@ class MessageHandler {
                                             })
                                         );
                                     } catch (err) {
-                                        return reject(err); // in case inner promise rejects just in case reject the outer too
+                                        return reject(err); // inner promise rejects -> just in case reject the outer too
                                     }
                                 } else {
                                     return resolve(updateMessage());

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -272,7 +272,7 @@ class MessageHandler {
                 prepared = newPrepared; // overwrite top-level original prepared
                 options.maildata = this.indexer.getMaildata(newPrepared.mimeTree); // get new maildata of encrypted message
             } else {
-                // not already encrypted and no need to / cannot ecnrypt
+                // not already encrypted and no need to / cannot encrypt
                 const newPrepared = await this.prepareMessageAsync(options);
                 prepared = newPrepared;
             }

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -915,451 +915,482 @@ class MessageHandler {
     }
 
     move(options, callback) {
-        this.getMailbox(options.source, (err, mailboxData) => {
-            if (err) {
-                return callback(err);
+        this.moveAsync(options)
+            .then(movedMessageRes => callback(null, ...movedMessageRes))
+            .catch(err => callback(err));
+    }
+
+    async moveAsync(options) {
+        // concurrent promises
+        const [mailboxData, targetData] = await Promise.all([this.getMailboxAsync(options.source), this.getMailboxAsync(options.destination)]);
+
+        const item = await this.database.collection('mailboxes').findOneAndUpdate(
+            {
+                _id: mailboxData._id
+            },
+            {
+                $inc: {
+                    // increase the mailbox modification index
+                    // to indicate that something happened
+                    modifyIndex: 1
+                }
+            },
+            {
+                returnDocument: 'after',
+                projection: {
+                    _id: true,
+                    uidNext: true,
+                    modifyIndex: true
+                }
+            }
+        );
+
+        let newModseq = (item && item.value && item.value.modifyIndex) || 1;
+
+        let cursor = this.database
+            .collection('messages')
+            .find({
+                mailbox: mailboxData._id,
+                uid: options.messageQuery ? options.messageQuery : tools.checkRangeQuery(options.messages)
+            })
+            // ordering is needed for IMAP UIDPLUS results
+            .sort({ uid: 1 });
+
+        let sourceUid = [];
+        let destinationUid = [];
+
+        let removeEntries = [];
+        let existsEntries = [];
+
+        let done = async err => {
+            let next = () => {
+                if (err) {
+                    throw err;
+                }
+                return [
+                    true,
+                    {
+                        uidValidity: targetData.uidValidity,
+                        sourceUid,
+                        destinationUid,
+                        mailbox: mailboxData._id,
+                        target: targetData._id,
+                        status: 'moved'
+                    }
+                ];
+            };
+
+            if (sourceUid.length && options.showExpunged) {
+                options.session.writeStream.write({
+                    tag: '*',
+                    command: String(options.session.selected.uidList.length),
+                    attributes: [
+                        {
+                            type: 'atom',
+                            value: 'EXISTS'
+                        }
+                    ]
+                });
             }
 
-            this.getMailbox(options.destination, (err, targetData) => {
-                if (err) {
-                    return callback(err);
-                }
+            if (existsEntries.length) {
+                // mark messages as deleted from old mailbox
+                return await new Promise((resolve, reject) => {
+                    this.notifier.addEntries(mailboxData, removeEntries, () => {
+                        // mark messages as added to new mailbox
+                        this.notifier.addEntries(targetData, existsEntries, () => {
+                            this.notifier.fire(mailboxData.user);
 
-                this.database.collection('mailboxes').findOneAndUpdate(
+                            try {
+                                resolve(next()); // resolve with return value of next()
+                            } catch (err) {
+                                reject(err);
+                            }
+                        });
+                    });
+                });
+            }
+
+            return next();
+        };
+
+        let processNext = async () => {
+            let message;
+            try {
+                message = await cursor.next();
+
+                if (!message) {
+                    await cursor.close(); // close cursor
+                    return done();
+                }
+            } catch (err) {
+                return done(err);
+            }
+
+            let messageId = message._id;
+            let messageUid = message.uid;
+
+            if (options.returnIds) {
+                sourceUid.push(message._id);
+            } else {
+                sourceUid.push(messageUid);
+            }
+
+            let item;
+
+            try {
+                item = await this.database.collection('mailboxes').findOneAndUpdate(
                     {
-                        _id: mailboxData._id
+                        _id: targetData._id
                     },
                     {
                         $inc: {
-                            // increase the mailbox modification index
-                            // to indicate that something happened
-                            modifyIndex: 1
+                            uidNext: 1
                         }
                     },
                     {
-                        returnDocument: 'after',
                         projection: {
-                            _id: true,
                             uidNext: true,
                             modifyIndex: true
-                        }
-                    },
-                    (err, item) => {
-                        if (err) {
-                            return callback(err);
-                        }
-
-                        let newModseq = (item && item.value && item.value.modifyIndex) || 1;
-
-                        let cursor = this.database
-                            .collection('messages')
-                            .find({
-                                mailbox: mailboxData._id,
-                                uid: options.messageQuery ? options.messageQuery : tools.checkRangeQuery(options.messages)
-                            })
-                            // ordering is needed for IMAP UIDPLUS results
-                            .sort({ uid: 1 });
-
-                        let sourceUid = [];
-                        let destinationUid = [];
-
-                        let removeEntries = [];
-                        let existsEntries = [];
-
-                        let done = err => {
-                            let next = () => {
-                                if (err) {
-                                    return callback(err);
-                                }
-                                return callback(null, true, {
-                                    uidValidity: targetData.uidValidity,
-                                    sourceUid,
-                                    destinationUid,
-                                    mailbox: mailboxData._id,
-                                    target: targetData._id,
-                                    status: 'moved'
-                                });
-                            };
-
-                            if (sourceUid.length && options.showExpunged) {
-                                options.session.writeStream.write({
-                                    tag: '*',
-                                    command: String(options.session.selected.uidList.length),
-                                    attributes: [
-                                        {
-                                            type: 'atom',
-                                            value: 'EXISTS'
-                                        }
-                                    ]
-                                });
-                            }
-
-                            if (existsEntries.length) {
-                                // mark messages as deleted from old mailbox
-                                return this.notifier.addEntries(mailboxData, removeEntries, () => {
-                                    // mark messages as added to new mailbox
-                                    this.notifier.addEntries(targetData, existsEntries, () => {
-                                        this.notifier.fire(mailboxData.user);
-                                        next();
-                                    });
-                                });
-                            }
-
-                            next();
-                        };
-
-                        let processNext = () => {
-                            cursor.next((err, message) => {
-                                if (err) {
-                                    return done(err);
-                                }
-                                if (!message) {
-                                    return cursor.close(done);
-                                }
-
-                                let messageId = message._id;
-                                let messageUid = message.uid;
-
-                                if (options.returnIds) {
-                                    sourceUid.push(message._id);
-                                } else {
-                                    sourceUid.push(messageUid);
-                                }
-
-                                this.database.collection('mailboxes').findOneAndUpdate(
-                                    {
-                                        _id: targetData._id
-                                    },
-                                    {
-                                        $inc: {
-                                            uidNext: 1
-                                        }
-                                    },
-                                    {
-                                        projection: {
-                                            uidNext: true,
-                                            modifyIndex: true
-                                        },
-                                        returnDocument: 'before'
-                                    },
-                                    (err, item) => {
-                                        if (err) {
-                                            return cursor.close(() => done(err));
-                                        }
-
-                                        if (!item || !item.value) {
-                                            return cursor.close(() => done(new Error('Mailbox disappeared')));
-                                        }
-
-                                        message._id = new ObjectId();
-
-                                        let uidNext = item.value.uidNext;
-                                        let modifyIndex = item.value.modifyIndex;
-
-                                        if (options.returnIds) {
-                                            destinationUid.push(message._id);
-                                        } else {
-                                            destinationUid.push(uidNext);
-                                        }
-
-                                        // set new mailbox
-                                        message.mailbox = targetData._id;
-
-                                        // new mailbox means new UID
-                                        message.uid = uidNext;
-
-                                        // retention settings
-                                        message.exp = !!targetData.retention;
-                                        message.rdate = Date.now() + (targetData.retention || 0);
-                                        message.modseq = modifyIndex; // reset message modseq to whatever it is for the mailbox right now
-
-                                        let unseen = message.unseen;
-
-                                        if (!message.flags.includes('\\Deleted')) {
-                                            message.searchable = true;
-                                        } else {
-                                            delete message.searchable;
-                                        }
-
-                                        let junk = false;
-                                        if (targetData.specialUse === '\\Junk' && !message.junk) {
-                                            message.junk = true;
-                                            junk = 1;
-                                        } else if (targetData.specialUse !== '\\Trash' && message.junk) {
-                                            delete message.junk;
-                                            junk = -1;
-                                        }
-
-                                        Object.keys(options.updates || {}).forEach(key => {
-                                            switch (key) {
-                                                case 'seen':
-                                                case 'deleted':
-                                                    {
-                                                        let fname = '\\' + key.charAt(0).toUpperCase() + key.substr(1);
-
-                                                        if (options.updates[key] && !message.flags.includes(fname)) {
-                                                            // add missing flag
-                                                            message.flags.push(fname);
-                                                        } else if (!options.updates[key] && message.flags.includes(fname)) {
-                                                            // remove non-needed flag
-                                                            let flags = new Set(message.flags);
-                                                            flags.delete(fname);
-                                                            message.flags = Array.from(flags);
-                                                        }
-                                                        message['un' + key] = !options.updates[key];
-                                                    }
-                                                    break;
-
-                                                case 'flagged':
-                                                case 'draft':
-                                                    {
-                                                        let fname = '\\' + key.charAt(0).toUpperCase() + key.substr(1);
-                                                        if (options.updates[key] && !message.flags.includes(fname)) {
-                                                            // add missing flag
-                                                            message.flags.push(fname);
-                                                        } else if (!options.updates[key] && message.flags.includes(fname)) {
-                                                            // remove non-needed flag
-                                                            let flags = new Set(message.flags);
-                                                            flags.delete(fname);
-                                                            message.flags = Array.from(flags);
-                                                        }
-                                                        message[key] = options.updates[key];
-                                                    }
-                                                    break;
-
-                                                case 'expires':
-                                                    {
-                                                        if (options.updates.expires) {
-                                                            message.exp = true;
-                                                            message.rdate = options.updates.expires.getTime();
-                                                        } else {
-                                                            message.exp = false;
-                                                        }
-                                                    }
-                                                    break;
-
-                                                case 'metaData':
-                                                    message.meta = message.meta || {};
-                                                    message.meta.custom = options.updates.metaData;
-                                                    break;
-
-                                                case 'outbound':
-                                                    message.outbound = [].concat(message.outbound || []).concat(options.updates.outbound || []);
-                                                    break;
-                                            }
-                                        });
-
-                                        if (options.markAsSeen) {
-                                            message.unseen = false;
-                                            if (!message.flags.includes('\\Seen')) {
-                                                message.flags.push('\\Seen');
-                                            }
-                                        }
-
-                                        const updateMessage = () => {
-                                            this.database.collection('messages').insertOne(message, { writeConcern: 'majority' }, (err, r) => {
-                                                if (err) {
-                                                    return cursor.close(() => done(err));
-                                                }
-
-                                                if (!r || !r.acknowledged) {
-                                                    let err = new Error('Failed to store message [2]');
-                                                    err.responseCode = 500;
-                                                    err.code = 'StoreError';
-                                                    return cursor.close(() => done(err));
-                                                }
-
-                                                let insertId = r.insertedId;
-
-                                                // delete old message
-                                                this.database.collection('messages').deleteOne(
-                                                    {
-                                                        _id: messageId,
-                                                        mailbox: mailboxData._id,
-                                                        uid: messageUid
-                                                    },
-                                                    { writeConcern: 'majority' },
-                                                    (err, r) => {
-                                                        if (err) {
-                                                            return cursor.close(() => done(err));
-                                                        }
-
-                                                        if (r && r.deletedCount) {
-                                                            if (options.session) {
-                                                                options.session.writeStream.write(options.session.formatResponse('EXPUNGE', sourceUid));
-                                                            }
-
-                                                            removeEntries.push({
-                                                                command: 'EXPUNGE',
-                                                                ignore: options.session && options.session.id,
-                                                                uid: messageUid,
-                                                                message: messageId,
-                                                                unseen,
-                                                                // modseq is needed to avoid updating mailbox entry
-                                                                modseq: newModseq
-                                                            });
-
-                                                            if (options.showExpunged) {
-                                                                options.session.writeStream.write(options.session.formatResponse('EXPUNGE', messageUid));
-                                                            }
-                                                        }
-
-                                                        let entry = {
-                                                            command: 'EXISTS',
-                                                            uid: uidNext,
-                                                            message: insertId,
-                                                            unseen: message.unseen,
-                                                            idate: message.idate,
-                                                            thread: message.thread
-                                                        };
-                                                        if (junk) {
-                                                            entry.junk = junk;
-                                                        }
-                                                        existsEntries.push(entry);
-
-                                                        if (existsEntries.length >= consts.BULK_BATCH_SIZE) {
-                                                            // mark messages as deleted from old mailbox
-                                                            return this.notifier.addEntries(mailboxData, removeEntries, () => {
-                                                                // mark messages as added to new mailbox
-                                                                this.notifier.addEntries(targetData, existsEntries, () => {
-                                                                    removeEntries = [];
-                                                                    existsEntries = [];
-                                                                    this.notifier.fire(mailboxData.user);
-                                                                    processNext();
-                                                                });
-                                                            });
-                                                        }
-                                                        processNext();
-                                                    }
-                                                );
-                                            });
-                                        };
-
-                                        if (targetData.encryptMessages) {
-                                            // move target mailbox is encrypted
-                                            const parsedHeader = (message.mimeTree && message.mimeTree.parsedHeader) || {};
-                                            const parsedContentType = parsedHeader['content-type'];
-
-                                            if (parsedContentType && parsedContentType.subtype === 'encrypted') {
-                                                // message already encrypted, just continue move
-                                                updateMessage();
-                                            } else {
-                                                // not yet encrypted
-                                                this.users.collection('users').findOne({ _id: mailboxData.user }, (err, res) => {
-                                                    if (err) {
-                                                        return done(err);
-                                                    }
-                                                    // get user data
-                                                    if (!res.pubKey) {
-                                                        return updateMessage();
-                                                    }
-
-                                                    // get raw from existing mimetree
-                                                    let outputStream = this.indexer.rebuild(message.mimeTree); // get raw rebuilder response obj (.value is the stream)
-
-                                                    if (!outputStream || outputStream.type !== 'stream' || !outputStream.value) {
-                                                        return done(new Error('Cannot fetch message'));
-                                                    }
-                                                    outputStream = outputStream.value; // set stream to actual stream object (.value)
-
-                                                    let chunks = [];
-                                                    let chunklen = 0;
-                                                    outputStream
-                                                        .on('readable', () => {
-                                                            let chunk;
-                                                            while ((chunk = outputStream.read()) !== null) {
-                                                                chunks.push(chunk);
-                                                                chunklen += chunk.length;
-                                                            }
-                                                        })
-                                                        .on('end', () => {
-                                                            // when done rebuilding
-                                                            const raw = Buffer.concat(chunks, chunklen);
-                                                            this.encryptMessage(res.pubKey, raw, (err, res) => {
-                                                                if (err) {
-                                                                    return done(err);
-                                                                }
-
-                                                                // encrypt rebuilt raw
-
-                                                                if (res) {
-                                                                    // encrypted
-                                                                    this.prepareMessage({ raw: res }, (err, prepared) => {
-                                                                        if (err) {
-                                                                            return done(err);
-                                                                        }
-                                                                        // prepare new message structure from encrypted raw
-
-                                                                        prepared.id = message.id; // reuse existing id
-
-                                                                        const maildata = this.indexer.getMaildata(prepared.mimeTree); // get new maildata
-
-                                                                        // add attachments of encrypted messages
-                                                                        if (maildata.attachments && maildata.attachments.length) {
-                                                                            message.attachments = maildata.attachments;
-                                                                            message.ha = maildata.attachments.some(a => !a.related);
-                                                                        } else {
-                                                                            message.ha = false;
-                                                                        }
-
-                                                                        // remove fields that may leak data in FE or DB
-                                                                        delete message.text;
-                                                                        delete message.html;
-                                                                        message.intro = '';
-
-                                                                        this.indexer.storeNodeBodies(maildata, prepared.mimeTree, err => {
-                                                                            // store new attachments
-                                                                            let cleanup = (...args) => {
-                                                                                if (!args[0]) {
-                                                                                    return callback(...args);
-                                                                                }
-
-                                                                                let attachmentIds = Object.keys(prepared.mimeTree.attachmentMap || {}).map(
-                                                                                    key => prepared.mimeTree.attachmentMap[key]
-                                                                                );
-                                                                                if (!attachmentIds.length) {
-                                                                                    return callback(...args);
-                                                                                }
-
-                                                                                this.attachmentStorage.deleteMany(attachmentIds, maildata.magic, () =>
-                                                                                    callback(...args)
-                                                                                );
-                                                                            };
-
-                                                                            if (err) {
-                                                                                return cleanup(err);
-                                                                            }
-
-                                                                            // overwrite required values of existing message with new values
-                                                                            message.mimeTree = prepared.mimeTree;
-                                                                            message.size = prepared.size;
-                                                                            message.bodystructure = prepared.bodystructure;
-                                                                            message.envelope = prepared.envelope;
-                                                                            message.headers = prepared.headers;
-                                                                            updateMessage();
-                                                                        });
-                                                                    });
-                                                                } else {
-                                                                    updateMessage();
-                                                                }
-                                                            });
-                                                        });
-                                                });
-                                            }
-                                        } else {
-                                            // move target is not encrypted so proceed
-                                            updateMessage();
-                                        }
-                                    }
-                                );
-                            });
-                        };
-
-                        processNext();
+                        },
+                        returnDocument: 'before'
                     }
                 );
+
+                if (!item || !item.value) {
+                    await cursor.close();
+                    return done(new Error('Mailbox disappeared'));
+                }
+            } catch (err) {
+                await cursor.close();
+                return done(err);
+            }
+
+            message._id = new ObjectId();
+
+            let uidNext = item.value.uidNext;
+            let modifyIndex = item.value.modifyIndex;
+
+            if (options.returnIds) {
+                destinationUid.push(message._id);
+            } else {
+                destinationUid.push(uidNext);
+            }
+
+            // set new mailbox
+            message.mailbox = targetData._id;
+
+            // new mailbox means new UID
+            message.uid = uidNext;
+
+            // retention settings
+            message.exp = !!targetData.retention;
+            message.rdate = Date.now() + (targetData.retention || 0);
+            message.modseq = modifyIndex; // reset message modseq to whatever it is for the mailbox right now
+
+            let unseen = message.unseen;
+
+            if (!message.flags.includes('\\Deleted')) {
+                message.searchable = true;
+            } else {
+                delete message.searchable;
+            }
+
+            let junk = false;
+            if (targetData.specialUse === '\\Junk' && !message.junk) {
+                message.junk = true;
+                junk = 1;
+            } else if (targetData.specialUse !== '\\Trash' && message.junk) {
+                delete message.junk;
+                junk = -1;
+            }
+
+            Object.keys(options.updates || {}).forEach(key => {
+                switch (key) {
+                    case 'seen':
+                    case 'deleted':
+                        {
+                            let fname = '\\' + key.charAt(0).toUpperCase() + key.substr(1);
+
+                            if (options.updates[key] && !message.flags.includes(fname)) {
+                                // add missing flag
+                                message.flags.push(fname);
+                            } else if (!options.updates[key] && message.flags.includes(fname)) {
+                                // remove non-needed flag
+                                let flags = new Set(message.flags);
+                                flags.delete(fname);
+                                message.flags = Array.from(flags);
+                            }
+                            message['un' + key] = !options.updates[key];
+                        }
+                        break;
+
+                    case 'flagged':
+                    case 'draft':
+                        {
+                            let fname = '\\' + key.charAt(0).toUpperCase() + key.substr(1);
+                            if (options.updates[key] && !message.flags.includes(fname)) {
+                                // add missing flag
+                                message.flags.push(fname);
+                            } else if (!options.updates[key] && message.flags.includes(fname)) {
+                                // remove non-needed flag
+                                let flags = new Set(message.flags);
+                                flags.delete(fname);
+                                message.flags = Array.from(flags);
+                            }
+                            message[key] = options.updates[key];
+                        }
+                        break;
+
+                    case 'expires':
+                        {
+                            if (options.updates.expires) {
+                                message.exp = true;
+                                message.rdate = options.updates.expires.getTime();
+                            } else {
+                                message.exp = false;
+                            }
+                        }
+                        break;
+
+                    case 'metaData':
+                        message.meta = message.meta || {};
+                        message.meta.custom = options.updates.metaData;
+                        break;
+
+                    case 'outbound':
+                        message.outbound = [].concat(message.outbound || []).concat(options.updates.outbound || []);
+                        break;
+                }
             });
-        });
+
+            if (options.markAsSeen) {
+                message.unseen = false;
+                if (!message.flags.includes('\\Seen')) {
+                    message.flags.push('\\Seen');
+                }
+            }
+
+            const updateMessage = async () => {
+                let r;
+
+                try {
+                    r = await this.database.collection('messages').insertOne(message, { writeConcern: 'majority' });
+
+                    if (!r || !r.acknowledged) {
+                        let err = new Error('Failed to store message [2]');
+                        err.responseCode = 500;
+                        err.code = 'StoreError';
+
+                        await cursor.close();
+                        return done(err);
+                    }
+                } catch (err) {
+                    await cursor.close();
+                    return done(err);
+                }
+
+                let insertId = r.insertedId;
+
+                // delete old message
+                let deleteMessageRes;
+
+                try {
+                    deleteMessageRes = await this.database.collection('messages').deleteOne(
+                        {
+                            _id: messageId,
+                            mailbox: mailboxData._id,
+                            uid: messageUid
+                        },
+                        { writeConcern: 'majority' }
+                    );
+                } catch (err) {
+                    await cursor.close();
+                    return done(err);
+                }
+
+                if (deleteMessageRes && deleteMessageRes.deletedCount) {
+                    if (options.session) {
+                        options.session.writeStream.write(options.session.formatResponse('EXPUNGE', sourceUid));
+                    }
+
+                    removeEntries.push({
+                        command: 'EXPUNGE',
+                        ignore: options.session && options.session.id,
+                        uid: messageUid,
+                        message: messageId,
+                        unseen,
+                        // modseq is needed to avoid updating mailbox entry
+                        modseq: newModseq
+                    });
+
+                    if (options.showExpunged) {
+                        options.session.writeStream.write(options.session.formatResponse('EXPUNGE', messageUid));
+                    }
+                }
+
+                let entry = {
+                    command: 'EXISTS',
+                    uid: uidNext,
+                    message: insertId,
+                    unseen: message.unseen,
+                    idate: message.idate,
+                    thread: message.thread
+                };
+                if (junk) {
+                    entry.junk = junk;
+                }
+                existsEntries.push(entry);
+
+                if (existsEntries.length >= consts.BULK_BATCH_SIZE) {
+                    // mark messages as deleted from old mailbox
+                    return new Promise(resolve => {
+                        this.notifier.addEntries(mailboxData, removeEntries, () => {
+                            // mark messages as added to new mailbox
+                            this.notifier.addEntries(targetData, existsEntries, () => {
+                                removeEntries = [];
+                                existsEntries = [];
+                                this.notifier.fire(mailboxData.user);
+                                resolve(processNext());
+                            });
+                        });
+                    });
+                }
+                return processNext();
+            };
+
+            if (targetData.encryptMessages) {
+                // move target mailbox is encrypted
+                const parsedHeader = (message.mimeTree && message.mimeTree.parsedHeader) || {};
+                const parsedContentType = parsedHeader['content-type'];
+
+                if (parsedContentType && parsedContentType.subtype === 'encrypted') {
+                    // message already encrypted, just continue move
+                    return updateMessage();
+                } else {
+                    // not yet encrypted, need to encrypt
+                    let res;
+
+                    try {
+                        res = await this.users.collection('users').findOne({ _id: mailboxData.user });
+                    } catch (err) {
+                        return done(err);
+                    }
+
+                    // get user data
+                    if (!res.pubKey) {
+                        // no public key available, cannot encrypt
+                        return updateMessage();
+                    }
+
+                    // get raw from existing mimetree
+                    let outputStream = this.indexer.rebuild(message.mimeTree); // get raw rebuilder response obj (.value is the stream)
+
+                    if (!outputStream || outputStream.type !== 'stream' || !outputStream.value) {
+                        return done(new Error('Cannot fetch message'));
+                    }
+                    outputStream = outputStream.value; // set stream to actual stream object (.value)
+
+                    let chunks = [];
+                    let chunklen = 0;
+
+                    return await new Promise((resolve, reject) => {
+                        outputStream
+                            .on('readable', () => {
+                                let chunk;
+                                while ((chunk = outputStream.read()) !== null) {
+                                    chunks.push(chunk);
+                                    chunklen += chunk.length;
+                                }
+                            })
+                            .on('end', async () => {
+                                // when done rebuilding
+                                const raw = Buffer.concat(chunks, chunklen);
+
+                                let encryptRes;
+
+                                try {
+                                    encryptRes = await this.encryptMessageAsync(res.pubKey, raw);
+                                } catch (err) {
+                                    return reject(done(err));
+                                }
+
+                                // encrypt rebuilt raw
+
+                                if (encryptRes) {
+                                    // encrypted
+                                    let prepared;
+
+                                    try {
+                                        prepared = await this.prepareMessageAsync({ raw: encryptRes });
+                                    } catch (err) {
+                                        return reject(done(err));
+                                    }
+
+                                    // prepare new message structure from encrypted raw
+
+                                    prepared.id = message.id; // reuse existing id
+
+                                    const maildata = this.indexer.getMaildata(prepared.mimeTree); // get new maildata
+
+                                    // add attachments of encrypted messages
+                                    if (maildata.attachments && maildata.attachments.length) {
+                                        message.attachments = maildata.attachments;
+                                        message.ha = maildata.attachments.some(a => !a.related);
+                                    } else {
+                                        message.ha = false;
+                                    }
+
+                                    // remove fields that may leak data in FE or DB
+                                    delete message.text;
+                                    delete message.html;
+                                    message.intro = '';
+
+                                    try {
+                                        // resolve inner promise in outer promise
+                                        return resolve(
+                                            await new Promise((resolve, reject) => {
+                                                this.indexer.storeNodeBodies(maildata, prepared.mimeTree, async err => {
+                                                    // store new attachments
+                                                    if (err) {
+                                                        let attachmentIds = Object.keys(prepared.mimeTree.attachmentMap || {}).map(
+                                                            key => prepared.mimeTree.attachmentMap[key]
+                                                        );
+                                                        if (!attachmentIds.length) {
+                                                            // with err, no attachments
+                                                            return reject(err);
+                                                        }
+
+                                                        await this.attachmentStorage.deleteMany(attachmentIds, maildata.magic);
+                                                        return reject(err); // reject from inner promise
+                                                    }
+
+                                                    // overwrite required values of existing message with new values
+                                                    message.mimeTree = prepared.mimeTree;
+                                                    message.size = prepared.size;
+                                                    message.bodystructure = prepared.bodystructure;
+                                                    message.envelope = prepared.envelope;
+                                                    message.headers = prepared.headers;
+                                                    return resolve(updateMessage());
+                                                });
+                                            })
+                                        );
+                                    } catch (err) {
+                                        return reject(err); // in case inner promise rejects just in case reject the outer too
+                                    }
+                                } else {
+                                    return resolve(updateMessage());
+                                }
+                            });
+                    });
+                }
+            } else {
+                // move target is not encrypted so proceed
+                return updateMessage();
+            }
+        };
+
+        return processNext();
     }
 
     // NB! does not update user quota

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -721,6 +721,7 @@ class MessageHandler {
         }
 
         await this.updateAddressRegister(mailboxData.user, addresses);
+        return finishFunc();
     }
 
     async updateQuotaAsync(user, inc, options) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -129,6 +129,12 @@ class MessageHandler {
             .catch(err => callback(err));
     }
 
+    add(options, callback) {
+        this.addAsync(options)
+            .then(messageAddedData => callback(null, ...messageAddedData))
+            .catch(err => callback(err));
+    }
+
     /**
      * Adds or updates messages in the address register that is needed for typeahead address search
      * @param {ObjectId} user
@@ -184,532 +190,536 @@ class MessageHandler {
 
     // Monster method for inserting new messages to a mailbox
     // TODO: Refactor into smaller pieces
-    add(options, callback) {
+    async addAsync(options) {
         if (!options.prepared && options.raw && options.raw.length > consts.MAX_ALLOWED_MESSAGE_SIZE) {
-            return setImmediate(() => callback(new Error('Message size ' + options.raw.length + ' bytes is too large')));
+            throw new Error('Message size ' + options.raw.length + ' bytes is too large');
         }
 
-        this.getMailbox(options, (err, mailboxData) => {
-            if (err) {
-                return callback(err);
+        // get target mailbox data
+        let mailboxData = await this.getMailboxAsync(options);
+
+        options.targetMailboxEncrypted = !!mailboxData.encryptMessages;
+
+        // get target user data
+        const userData = await this.users.collection('users').findOne({ _id: options.user });
+
+        let prepared = options.prepared; // might be undefined
+
+        // check if already encrypted
+        let alreadyEncrypted = false;
+
+        // message already prepared, check if encrypted
+        if (prepared) {
+            // got prepared
+            const parsedHeader = (prepared.mimeTree && prepared.mimeTree?.parsedHeader) || {};
+            const parsedContentType = parsedHeader['content-type'];
+
+            if (parsedContentType && parsedContentType.subtype === 'encrypted') {
+                alreadyEncrypted = true;
+            }
+        } else {
+            // no prepared, use raw
+            if (options.rawchunks && !options.raw) {
+                // got rawchunks instead of raw
+                if (options.chunklen) {
+                    options.raw = Buffer.concat(options.rawchunks, options.chunklen);
+                } else {
+                    options.raw = Buffer.concat(options.rawchunks);
+                }
             }
 
-            // get target mailbox data
+            const rawString = options.raw.toString('binary'); // get string from the raw bytes of message
+            const regex = /Content-Type:\s*multipart\/encrypted/gim;
 
-            options.targetMailboxEncrypted = !!mailboxData.encryptMessages;
+            if (regex.test(rawString)) {
+                // if there is encrypted content-type then message already encrypted, no need to re-encrypt it
+                alreadyEncrypted = true;
+            }
+        }
 
-            this.users.collection('users').findOne({ _id: options.user }, (err, userData) => {
-                if (err) {
-                    return callback(err);
-                }
+        let flags = Array.isArray(options.flags) ? options.flags : [].concat(options.flags || []);
 
-                // get target user data
-                let prepared = options.prepared; // might be undefined
-
-                // check if already encrypted
-                let alreadyEncrypted = false;
-
-                // message already prepared, check if encrypted
-                if (prepared) {
-                    // got prepared
-                    const parsedHeader = (prepared.mimeTree && prepared.mimeTree?.parsedHeader) || {};
-                    const parsedContentType = parsedHeader['content-type'];
-
-                    if (parsedContentType && parsedContentType.subtype === 'encrypted') {
-                        alreadyEncrypted = true;
-                    }
-                } else {
-                    // no prepared, use raw
-                    if (options.rawchunks && !options.raw) {
-                        // got rawchunks instead of raw
-                        if (options.chunklen) {
-                            options.raw = Buffer.concat(options.rawchunks, options.chunklen);
-                        } else {
-                            options.raw = Buffer.concat(options.rawchunks);
-                        }
-                    }
-
-                    const rawString = options.raw.toString('binary'); // get string from the raw bytes of message
-                    const regex = /Content-Type:\s*multipart\/encrypted/gim;
-
-                    if (regex.test(rawString)) {
-                        // if there is encrypted content-type then message already encrypted, no need to re-encrypt it
-                        alreadyEncrypted = true;
+        if (!alreadyEncrypted) {
+            // not already encrypted, check if user has encryption on or target mailbox is encrypted
+            if ((userData.encryptMessages || !!mailboxData.encryptMessages) && userData.pubKey && !flags.includes('\\Draft')) {
+                if (options.rawchunks && !options.raw) {
+                    // got rawchunks instead of raw
+                    if (options.chunklen) {
+                        options.raw = Buffer.concat(options.rawchunks, options.chunklen);
+                    } else {
+                        options.raw = Buffer.concat(options.rawchunks);
                     }
                 }
+                // user has encryption on or target mailbox encrypted, encrypt message and prepare again
+                // do not encrypt drafts
+                // may have a situation where we got prepared and no options.raw but options.rawchunks instead, concat them
 
-                let flags = Array.isArray(options.flags) ? options.flags : [].concat(options.flags || []);
+                const encrypted = await this.encryptMessageAsync(userData.pubKey, options.raw);
 
-                let addMessage = () => {
-                    let id = prepared.id;
-                    let mimeTree = prepared.mimeTree;
-                    let size = prepared.size;
-                    let bodystructure = prepared.bodystructure;
-                    let envelope = prepared.envelope;
-                    let idate = prepared.idate;
-                    let hdate = prepared.hdate;
-                    let msgid = prepared.msgid;
-                    let subject = prepared.subject;
-                    let headers = prepared.headers;
+                if (encrypted) {
+                    // new encrypted raw available
+                    options.raw = encrypted;
+                }
 
-                    let maildata = options.maildata || this.indexer.getMaildata(mimeTree);
+                delete options.prepared; // delete any existing prepared as new will be generated
+                const newPrepared = await this.prepareMessageAsync(options);
 
-                    let cleanup = (...args) => {
-                        if (!args[0]) {
-                            return callback(...args);
+                newPrepared.id = prepared.id; // retain original
+
+                options.prepared = newPrepared; // new prepared in options just in case
+                prepared = newPrepared; // overwrite top-level original prepared
+                options.maildata = this.indexer.getMaildata(newPrepared.mimeTree); // get new maildata of encrypted message
+            } else {
+                // not already encrypted and no need to / cannot ecnrypt
+                const newPrepared = await this.prepareMessageAsync(options);
+                prepared = newPrepared;
+            }
+        } else {
+            // message already encrypted
+            const newPrepared = await this.prepareMessageAsync(options);
+            prepared = newPrepared;
+        }
+
+        let id = prepared.id;
+        let mimeTree = prepared.mimeTree;
+        let size = prepared.size;
+        let bodystructure = prepared.bodystructure;
+        let envelope = prepared.envelope;
+        let idate = prepared.idate;
+        let hdate = prepared.hdate;
+        let msgid = prepared.msgid;
+        let subject = prepared.subject;
+        let headers = prepared.headers;
+
+        let maildata = options.maildata || this.indexer.getMaildata(mimeTree);
+
+        let cleanup = async (err, status, data) => {
+            if (!err) {
+                // no error
+                return [status, data];
+            }
+
+            let attachmentIds = Object.keys(mimeTree.attachmentMap || {}).map(key => mimeTree.attachmentMap[key]);
+            if (!attachmentIds.length) {
+                // with err, no attachments
+                throw err;
+            }
+
+            // with err, with attachments
+            try {
+                await this.attachmentStorage.deleteMany(attachmentIds, maildata.magic);
+                throw err;
+            } catch (ignore) {
+                throw err;
+            }
+        };
+
+        try {
+            await new Promise((resolve, reject) => {
+                this.indexer.storeNodeBodies(maildata, mimeTree, err => {
+                    if (err) {
+                        return reject(err);
+                    }
+                    return resolve();
+                });
+            });
+        } catch (err) {
+            return cleanup(err);
+        }
+
+        // prepare message object
+        let messageData = {
+            _id: id,
+
+            // should be kept when COPY'ing or MOVE'ing
+            root: id,
+
+            v: consts.SCHEMA_VERSION,
+
+            // if true then expires after rdate + retention
+            exp: !!mailboxData.retention,
+            rdate: Date.now() + (mailboxData.retention || 0),
+
+            // make sure the field exists. it is set to true when user is deleted
+            userDeleted: false,
+
+            idate,
+            hdate,
+            flags,
+            size,
+
+            // some custom metadata about the delivery
+            meta: options.meta || {},
+
+            // list filter IDs that matched this message
+            filters: Array.isArray(options.filters) ? options.filters : [].concat(options.filters || []),
+
+            headers,
+            mimeTree,
+            envelope,
+            bodystructure,
+            msgid,
+
+            // use boolean for more commonly used (and searched for) flags
+            unseen: !flags.includes('\\Seen'),
+            flagged: flags.includes('\\Flagged'),
+            undeleted: !flags.includes('\\Deleted'),
+            draft: flags.includes('\\Draft'),
+
+            magic: maildata.magic,
+
+            subject,
+
+            // do not archive deleted messages that have been copied
+            copied: false
+        };
+
+        if (options.verificationResults) {
+            messageData.verificationResults = options.verificationResults;
+        }
+
+        if (options.outbound) {
+            messageData.outbound = [].concat(options.outbound || []);
+        }
+
+        if (options.forwardTargets) {
+            messageData.forwardTargets = [].concat(options.forwardTargets || []);
+        }
+
+        if (maildata.attachments && maildata.attachments.length) {
+            messageData.attachments = maildata.attachments;
+            messageData.ha = maildata.attachments.some(a => !a.related);
+        } else {
+            messageData.ha = false;
+        }
+
+        if (maildata.text) {
+            messageData.text = maildata.text.replace(/\r\n/g, '\n').trim();
+
+            // text is indexed with a fulltext index, so only store the beginning of it
+            if (messageData.text.length > consts.MAX_PLAINTEXT_INDEXED) {
+                messageData.textFooter = messageData.text.substr(consts.MAX_PLAINTEXT_INDEXED);
+                messageData.text = messageData.text.substr(0, consts.MAX_PLAINTEXT_INDEXED);
+
+                // truncate remaining text if total length exceeds maximum allowed
+                if (
+                    consts.MAX_PLAINTEXT_CONTENT > consts.MAX_PLAINTEXT_INDEXED &&
+                    messageData.textFooter.length > consts.MAX_PLAINTEXT_CONTENT - consts.MAX_PLAINTEXT_INDEXED
+                ) {
+                    messageData.textFooter = messageData.textFooter.substr(0, consts.MAX_PLAINTEXT_CONTENT - consts.MAX_PLAINTEXT_INDEXED);
+                }
+            }
+            messageData.text =
+                messageData.text.length <= consts.MAX_PLAINTEXT_CONTENT ? messageData.text : messageData.text.substr(0, consts.MAX_PLAINTEXT_CONTENT);
+
+            messageData.intro = this.createIntro(messageData.text);
+        }
+
+        if (maildata.html && maildata.html.length) {
+            let htmlSize = 0;
+            messageData.html = maildata.html
+                .map(html => {
+                    if (htmlSize >= consts.MAX_HTML_CONTENT || !html) {
+                        return '';
+                    }
+
+                    if (htmlSize + Buffer.byteLength(html) <= consts.MAX_HTML_CONTENT) {
+                        htmlSize += Buffer.byteLength(html);
+                        return html;
+                    }
+
+                    html = html.substr(0, consts.MAX_HTML_CONTENT);
+                    htmlSize += Buffer.byteLength(html);
+                    return html;
+                })
+                .filter(html => html);
+
+            // if message has HTML content use it instead of text/plain content for intro
+            messageData.intro = this.createIntro(htmlToText(messageData.html.join('')));
+        }
+
+        let r;
+
+        try {
+            r = await this.users.collection('users').findOneAndUpdate(
+                {
+                    _id: mailboxData.user
+                },
+                {
+                    $inc: {
+                        storageUsed: size
+                    }
+                },
+                {
+                    returnDocument: 'after',
+                    projection: {
+                        storageUsed: true
+                    }
+                }
+            );
+        } catch (err) {
+            return cleanup(err);
+        }
+
+        if (r && r.value) {
+            this.loggelf({
+                short_message: '[QUOTA] +',
+                _mail_action: 'quota',
+                _user: mailboxData.user,
+                _inc: size,
+                _storage_used: r.value.storageUsed,
+                _sess: options.session && options.session.id,
+                _mailbox: mailboxData._id
+            });
+        }
+
+        let rollback = async rollbackError => {
+            let args;
+            try {
+                args = await this.users.collection('users').findOneAndUpdate(
+                    {
+                        _id: mailboxData.user
+                    },
+                    {
+                        $inc: {
+                            storageUsed: -size
                         }
-
-                        let attachmentIds = Object.keys(mimeTree.attachmentMap || {}).map(key => mimeTree.attachmentMap[key]);
-                        if (!attachmentIds.length) {
-                            return callback(...args);
+                    },
+                    {
+                        returnDocument: 'after',
+                        projection: {
+                            storageUsed: true
                         }
+                    }
+                );
+            } catch (ignore) {
+                // ignore
+            }
 
-                        this.attachmentStorage.deleteMany(attachmentIds, maildata.magic, () => callback(...args));
-                    };
+            let r = args && args[1];
 
-                    this.indexer.storeNodeBodies(maildata, mimeTree, err => {
-                        if (err) {
-                            return cleanup(err);
-                        }
+            if (r && r.value) {
+                this.loggelf({
+                    short_message: '[QUOTA] -',
+                    _mail_action: 'quota',
+                    _user: mailboxData.user,
+                    _inc: -size,
+                    _storage_used: r.value.storageUsed,
+                    _sess: options.session && options.session.id,
+                    _mailbox: mailboxData._id,
+                    _rollback: 'yes',
+                    _error: rollbackError.message,
+                    _code: rollbackError.code
+                });
+            }
 
-                        // prepare message object
-                        let messageData = {
-                            _id: id,
+            return cleanup(rollbackError);
+        };
 
-                            // should be kept when COPY'ing or MOVE'ing
-                            root: id,
+        // acquire new UID+MODSEQ
 
-                            v: consts.SCHEMA_VERSION,
+        let item;
 
-                            // if true then expires after rdate + retention
-                            exp: !!mailboxData.retention,
-                            rdate: Date.now() + (mailboxData.retention || 0),
+        try {
+            item = await this.database.collection('mailboxes').findOneAndUpdate(
+                {
+                    _id: mailboxData._id
+                },
+                {
+                    $inc: {
+                        // allocate bot UID and MODSEQ values so when journal is later sorted by
+                        // modseq then UIDs are always in ascending order
+                        uidNext: 1,
+                        modifyIndex: 1
+                    }
+                },
+                {
+                    // use original value to get correct UIDNext
+                    returnDocument: 'before'
+                }
+            );
+        } catch (err) {
+            return rollback(err);
+        }
 
-                            // make sure the field exists. it is set to true when user is deleted
-                            userDeleted: false,
+        if (!item || !item.value) {
+            // was not able to acquire a lock
+            let err = new Error('Mailbox is missing');
+            err.imapResponse = 'TRYCREATE';
+            return rollback(err);
+        }
 
-                            idate,
-                            hdate,
-                            flags,
-                            size,
+        mailboxData = item.value;
 
-                            // some custom metadata about the delivery
-                            meta: options.meta || {},
+        // updated message object by setting mailbox specific values
+        messageData.mailbox = mailboxData._id;
+        messageData.user = mailboxData.user;
+        messageData.uid = mailboxData.uidNext;
+        messageData.modseq = mailboxData.modifyIndex + 1;
 
-                            // list filter IDs that matched this message
-                            filters: Array.isArray(options.filters) ? options.filters : [].concat(options.filters || []),
+        if (!flags.includes('\\Deleted')) {
+            messageData.searchable = true;
+        }
 
-                            headers,
-                            mimeTree,
-                            envelope,
-                            bodystructure,
-                            msgid,
+        if (mailboxData.specialUse === '\\Junk') {
+            messageData.junk = true;
+        }
 
-                            // use boolean for more commonly used (and searched for) flags
-                            unseen: !flags.includes('\\Seen'),
-                            flagged: flags.includes('\\Flagged'),
-                            undeleted: !flags.includes('\\Deleted'),
-                            draft: flags.includes('\\Draft'),
+        let thread;
 
-                            magic: maildata.magic,
+        try {
+            thread = await this.getThreadIdAsync(mailboxData.user, subject, mimeTree);
+        } catch (err) {
+            return rollback(err);
+        }
 
-                            subject,
+        messageData.thread = thread;
 
-                            // do not archive deleted messages that have been copied
-                            copied: false
-                        };
+        let insertRes;
 
-                        if (options.verificationResults) {
-                            messageData.verificationResults = options.verificationResults;
-                        }
+        try {
+            insertRes = await this.database.collection('messages').insertOne(messageData, { writeConcern: 'majority' });
+        } catch (err) {
+            return rollback(err);
+        }
 
-                        if (options.outbound) {
-                            messageData.outbound = [].concat(options.outbound || []);
-                        }
+        if (!insertRes || !insertRes.acknowledged) {
+            let err = new Error('Failed to store message [1]');
+            err.responseCode = 500;
+            err.code = 'StoreError';
+            return rollback(err);
+        }
 
-                        if (options.forwardTargets) {
-                            messageData.forwardTargets = [].concat(options.forwardTargets || []);
-                        }
+        let logTime = messageData.meta.time || new Date();
+        if (typeof logTime === 'number') {
+            logTime = new Date(logTime);
+        }
 
-                        if (maildata.attachments && maildata.attachments.length) {
-                            messageData.attachments = maildata.attachments;
-                            messageData.ha = maildata.attachments.some(a => !a.related);
-                        } else {
-                            messageData.ha = false;
-                        }
+        let uidValidity = mailboxData.uidValidity;
+        let uid = messageData.uid;
 
-                        if (maildata.text) {
-                            messageData.text = maildata.text.replace(/\r\n/g, '\n').trim();
+        if (
+            options.session &&
+            options.session.selected &&
+            options.session.selected.mailbox &&
+            options.session.selected.mailbox.toString() === mailboxData._id.toString()
+        ) {
+            options.session.writeStream.write(options.session.formatResponse('EXISTS', messageData.uid));
+        }
 
-                            // text is indexed with a fulltext index, so only store the beginning of it
-                            if (messageData.text.length > consts.MAX_PLAINTEXT_INDEXED) {
-                                messageData.textFooter = messageData.text.substr(consts.MAX_PLAINTEXT_INDEXED);
-                                messageData.text = messageData.text.substr(0, consts.MAX_PLAINTEXT_INDEXED);
+        let updateAddressRegister = async finishFunc => {
+            let addresses = [];
 
-                                // truncate remaining text if total length exceeds maximum allowed
-                                if (
-                                    consts.MAX_PLAINTEXT_CONTENT > consts.MAX_PLAINTEXT_INDEXED &&
-                                    messageData.textFooter.length > consts.MAX_PLAINTEXT_CONTENT - consts.MAX_PLAINTEXT_INDEXED
-                                ) {
-                                    messageData.textFooter = messageData.textFooter.substr(0, consts.MAX_PLAINTEXT_CONTENT - consts.MAX_PLAINTEXT_INDEXED);
-                                }
+            if (messageData.junk || flags.includes('\\Draft')) {
+                // skip junk and draft messages
+                return finishFunc();
+            }
+
+            let parsed = messageData.mimeTree && messageData.mimeTree.parsedHeader;
+
+            if (parsed) {
+                let keyList = mailboxData.specialUse === '\\Sent' ? ['to', 'cc', 'bcc'] : ['from'];
+
+                for (const disallowedHeader of DISALLOWED_HEADERS_FOR_ADDRESS_REGISTER) {
+                    // if email contains headers that we do not want,
+                    // don't add any emails to address register
+                    if (parsed[disallowedHeader]) {
+                        return finishFunc();
+                    }
+                }
+
+                for (let key of keyList) {
+                    if (parsed[key] && parsed[key].length) {
+                        for (let addr of parsed[key]) {
+                            if (/no-?reply/i.test(addr.address)) {
+                                continue;
                             }
-                            messageData.text =
-                                messageData.text.length <= consts.MAX_PLAINTEXT_CONTENT
-                                    ? messageData.text
-                                    : messageData.text.substr(0, consts.MAX_PLAINTEXT_CONTENT);
-
-                            messageData.intro = this.createIntro(messageData.text);
+                            if (!addresses.some(a => a.address === addr.address)) {
+                                addresses.push(addr);
+                            }
                         }
+                    }
+                }
+            }
 
-                        if (maildata.html && maildata.html.length) {
-                            let htmlSize = 0;
-                            messageData.html = maildata.html
-                                .map(html => {
-                                    if (htmlSize >= consts.MAX_HTML_CONTENT || !html) {
-                                        return '';
+            if (!addresses.length) {
+                return finishFunc();
+            }
+
+            try {
+                await this.updateAddressRegister(mailboxData.user, addresses);
+                return finishFunc();
+            } catch (err) {
+                return finishFunc(err);
+            }
+        };
+
+        return updateAddressRegister(
+            async () =>
+                new Promise(resolve => {
+                    this.notifier.addEntries(
+                        mailboxData,
+                        {
+                            command: 'EXISTS',
+                            uid: messageData.uid,
+                            ignore: options.session && options.session.id,
+                            message: messageData._id,
+                            modseq: messageData.modseq,
+                            unseen: messageData.unseen,
+                            idate: messageData.idate,
+                            thread: messageData.thread
+                        },
+                        async () => {
+                            // added Entries
+                            this.notifier.fire(mailboxData.user);
+
+                            let raw = options.rawchunks || options.raw;
+                            let processAudits = async () => {
+                                let audits = await this.database
+                                    .collection('audits')
+                                    .find({ user: mailboxData.user, expires: { $gt: new Date() } })
+                                    .toArray();
+
+                                let now = new Date();
+                                for (let auditData of audits) {
+                                    if ((auditData.start && auditData.start > now) || (auditData.end && auditData.end < now)) {
+                                        // audit not active
+                                        continue;
                                     }
-
-                                    if (htmlSize + Buffer.byteLength(html) <= consts.MAX_HTML_CONTENT) {
-                                        htmlSize += Buffer.byteLength(html);
-                                        return html;
-                                    }
-
-                                    html = html.substr(0, consts.MAX_HTML_CONTENT);
-                                    htmlSize += Buffer.byteLength(html);
-                                    return html;
-                                })
-                                .filter(html => html);
-
-                            // if message has HTML content use it instead of text/plain content for intro
-                            messageData.intro = this.createIntro(htmlToText(messageData.html.join('')));
-                        }
-
-                        this.users.collection('users').findOneAndUpdate(
-                            {
-                                _id: mailboxData.user
-                            },
-                            {
-                                $inc: {
-                                    storageUsed: size
-                                }
-                            },
-                            {
-                                returnDocument: 'after',
-                                projection: {
-                                    storageUsed: true
-                                }
-                            },
-                            (err, r) => {
-                                if (err) {
-                                    return cleanup(err);
-                                }
-
-                                if (r && r.value) {
-                                    this.loggelf({
-                                        short_message: '[QUOTA] +',
-                                        _mail_action: 'quota',
-                                        _user: mailboxData.user,
-                                        _inc: size,
-                                        _storage_used: r.value.storageUsed,
-                                        _sess: options.session && options.session.id,
-                                        _mailbox: mailboxData._id
+                                    await this.auditHandler.store(auditData._id, raw, {
+                                        date: messageData.idate,
+                                        msgid: messageData.msgid,
+                                        header: messageData.mimeTree && messageData.mimeTree.parsedHeader,
+                                        ha: messageData.ha,
+                                        mailbox: mailboxData._id,
+                                        mailboxPath: mailboxData.path,
+                                        info: Object.assign({ queueId: messageData.outbound }, messageData.meta)
                                     });
                                 }
+                            };
 
-                                let rollback = err => {
-                                    this.users.collection('users').findOneAndUpdate(
-                                        {
-                                            _id: mailboxData.user
-                                        },
-                                        {
-                                            $inc: {
-                                                storageUsed: -size
-                                            }
-                                        },
-                                        {
-                                            returnDocument: 'after',
-                                            projection: {
-                                                storageUsed: true
-                                            }
-                                        },
-                                        (...args) => {
-                                            let r = args && args[1];
+                            let next = () =>
+                                cleanup(null, true, {
+                                    uidValidity,
+                                    uid,
+                                    id: messageData._id.toString(),
+                                    mailbox: mailboxData._id.toString(),
+                                    mailboxPath: mailboxData.path,
+                                    size,
+                                    status: 'new'
+                                });
 
-                                            if (r && r.value) {
-                                                this.loggelf({
-                                                    short_message: '[QUOTA] -',
-                                                    _mail_action: 'quota',
-                                                    _user: mailboxData.user,
-                                                    _inc: -size,
-                                                    _storage_used: r.value.storageUsed,
-                                                    _sess: options.session && options.session.id,
-                                                    _mailbox: mailboxData._id,
-                                                    _rollback: 'yes',
-                                                    _error: err.message,
-                                                    _code: err.code
-                                                });
-                                            }
-
-                                            cleanup(err);
-                                        }
-                                    );
-                                };
-
-                                // acquire new UID+MODSEQ
-                                this.database.collection('mailboxes').findOneAndUpdate(
-                                    {
-                                        _id: mailboxData._id
-                                    },
-                                    {
-                                        $inc: {
-                                            // allocate bot UID and MODSEQ values so when journal is later sorted by
-                                            // modseq then UIDs are always in ascending order
-                                            uidNext: 1,
-                                            modifyIndex: 1
-                                        }
-                                    },
-                                    {
-                                        // use original value to get correct UIDNext
-                                        returnDocument: 'before'
-                                    },
-                                    (err, item) => {
-                                        if (err) {
-                                            return rollback(err);
-                                        }
-
-                                        if (!item || !item.value) {
-                                            // was not able to acquire a lock
-                                            let err = new Error('Mailbox is missing');
-                                            err.imapResponse = 'TRYCREATE';
-                                            return rollback(err);
-                                        }
-
-                                        let mailboxData = item.value;
-
-                                        // updated message object by setting mailbox specific values
-                                        messageData.mailbox = mailboxData._id;
-                                        messageData.user = mailboxData.user;
-                                        messageData.uid = mailboxData.uidNext;
-                                        messageData.modseq = mailboxData.modifyIndex + 1;
-
-                                        if (!flags.includes('\\Deleted')) {
-                                            messageData.searchable = true;
-                                        }
-
-                                        if (mailboxData.specialUse === '\\Junk') {
-                                            messageData.junk = true;
-                                        }
-
-                                        this.getThreadId(mailboxData.user, subject, mimeTree, (err, thread) => {
-                                            if (err) {
-                                                return rollback(err);
-                                            }
-
-                                            messageData.thread = thread;
-
-                                            this.database.collection('messages').insertOne(messageData, { writeConcern: 'majority' }, (err, r) => {
-                                                if (err) {
-                                                    return rollback(err);
-                                                }
-
-                                                if (!r || !r.acknowledged) {
-                                                    let err = new Error('Failed to store message [1]');
-                                                    err.responseCode = 500;
-                                                    err.code = 'StoreError';
-                                                    return rollback(err);
-                                                }
-
-                                                let logTime = messageData.meta.time || new Date();
-                                                if (typeof logTime === 'number') {
-                                                    logTime = new Date(logTime);
-                                                }
-
-                                                let uidValidity = mailboxData.uidValidity;
-                                                let uid = messageData.uid;
-
-                                                if (
-                                                    options.session &&
-                                                    options.session.selected &&
-                                                    options.session.selected.mailbox &&
-                                                    options.session.selected.mailbox.toString() === mailboxData._id.toString()
-                                                ) {
-                                                    options.session.writeStream.write(options.session.formatResponse('EXISTS', messageData.uid));
-                                                }
-
-                                                let updateAddressRegister = next => {
-                                                    let addresses = [];
-
-                                                    if (messageData.junk || flags.includes('\\Draft')) {
-                                                        // skip junk and draft messages
-                                                        return next();
-                                                    }
-
-                                                    let parsed = messageData.mimeTree && messageData.mimeTree.parsedHeader;
-
-                                                    if (parsed) {
-                                                        let keyList = mailboxData.specialUse === '\\Sent' ? ['to', 'cc', 'bcc'] : ['from'];
-
-                                                        for (const disallowedHeader of DISALLOWED_HEADERS_FOR_ADDRESS_REGISTER) {
-                                                            // if email contains headers that we do not want,
-                                                            // don't add any emails to address register
-                                                            if (parsed[disallowedHeader]) {
-                                                                return next();
-                                                            }
-                                                        }
-
-                                                        for (let key of keyList) {
-                                                            if (parsed[key] && parsed[key].length) {
-                                                                for (let addr of parsed[key]) {
-                                                                    if (/no-?reply/i.test(addr.address)) {
-                                                                        continue;
-                                                                    }
-                                                                    if (!addresses.some(a => a.address === addr.address)) {
-                                                                        addresses.push(addr);
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-
-                                                    if (!addresses.length) {
-                                                        return next();
-                                                    }
-
-                                                    this.updateAddressRegister(mailboxData.user, addresses)
-                                                        .then(() => next())
-                                                        .catch(err => next(err));
-                                                };
-
-                                                updateAddressRegister(() => {
-                                                    this.notifier.addEntries(
-                                                        mailboxData,
-                                                        {
-                                                            command: 'EXISTS',
-                                                            uid: messageData.uid,
-                                                            ignore: options.session && options.session.id,
-                                                            message: messageData._id,
-                                                            modseq: messageData.modseq,
-                                                            unseen: messageData.unseen,
-                                                            idate: messageData.idate,
-                                                            thread: messageData.thread
-                                                        },
-                                                        () => {
-                                                            this.notifier.fire(mailboxData.user);
-
-                                                            let raw = options.rawchunks || options.raw;
-                                                            let processAudits = async () => {
-                                                                let audits = await this.database
-                                                                    .collection('audits')
-                                                                    .find({ user: mailboxData.user, expires: { $gt: new Date() } })
-                                                                    .toArray();
-
-                                                                let now = new Date();
-                                                                for (let auditData of audits) {
-                                                                    if ((auditData.start && auditData.start > now) || (auditData.end && auditData.end < now)) {
-                                                                        // audit not active
-                                                                        continue;
-                                                                    }
-                                                                    await this.auditHandler.store(auditData._id, raw, {
-                                                                        date: messageData.idate,
-                                                                        msgid: messageData.msgid,
-                                                                        header: messageData.mimeTree && messageData.mimeTree.parsedHeader,
-                                                                        ha: messageData.ha,
-                                                                        mailbox: mailboxData._id,
-                                                                        mailboxPath: mailboxData.path,
-                                                                        info: Object.assign({ queueId: messageData.outbound }, messageData.meta)
-                                                                    });
-                                                                }
-                                                            };
-
-                                                            let next = () => {
-                                                                cleanup(null, true, {
-                                                                    uidValidity,
-                                                                    uid,
-                                                                    id: messageData._id.toString(),
-                                                                    mailbox: mailboxData._id.toString(),
-                                                                    mailboxPath: mailboxData.path,
-                                                                    size,
-                                                                    status: 'new'
-                                                                });
-                                                            };
-
-                                                            // do not use more suitable .finally() as it is not supported in Node v8
-                                                            return processAudits().then(next).catch(next);
-                                                        }
-                                                    );
-                                                });
-                                            });
-                                        });
-                                    }
-                                );
-                            }
-                        );
-                    });
-                };
-
-                if (!alreadyEncrypted) {
-                    // not already encrypted, check if user has encryption on or target mailbox is encrypted
-                    if ((userData.encryptMessages || !!mailboxData.encryptMessages) && userData.pubKey && !flags.includes('\\Draft')) {
-                        if (options.rawchunks && !options.raw) {
-                            // got rawchunks instead of raw
-                            if (options.chunklen) {
-                                options.raw = Buffer.concat(options.rawchunks, options.chunklen);
-                            } else {
-                                options.raw = Buffer.concat(options.rawchunks);
+                            // do not use more suitable .finally() as it is not supported in Node v8
+                            try {
+                                await processAudits();
+                                resolve(next());
+                            } catch (ignore) {
+                                resolve(next());
                             }
                         }
-                        // user has encryption on or target mailbox encrypted, encrypt message and prepare again
-                        // do not encrypt drafts
-                        // may have a situation where we got prepared and no options.raw but options.rawchunks instead, concat them
-                        this.encryptMessage(userData.pubKey, options.raw, (err, res) => {
-                            if (err) {
-                                return callback(err);
-                            }
-
-                            if (res) {
-                                // new encrypted raw available
-                                options.raw = res;
-                            }
-
-                            delete options.prepared; // delete any existing prepared as new will be generated
-                            this.prepareMessage(options, (err, newPrepared) => {
-                                if (err) {
-                                    return callback(err);
-                                }
-
-                                newPrepared.id = prepared.id; // retain original
-
-                                options.prepared = newPrepared; // new prepared in options just in case
-                                prepared = newPrepared; // overwrite top-level original prepared
-                                options.maildata = this.indexer.getMaildata(newPrepared.mimeTree); // get new maildata of encrypted message
-                                addMessage();
-                            });
-                        });
-                    } else {
-                        // not already encrypted and no need to
-                        this.prepareMessage(options, (err, newPrepared) => {
-                            if (err) {
-                                return callback(err);
-                            }
-
-                            prepared = newPrepared;
-                            addMessage();
-                        });
-                    }
-                } else {
-                    // message already encrypted
-                    this.prepareMessage(options, (err, newPrepared) => {
-                        if (err) {
-                            return callback(err);
-                        }
-
-                        prepared = newPrepared;
-                        addMessage();
-                    });
-                }
-            });
-        });
+                    );
+                })
+        );
     }
 
     async updateQuotaAsync(user, inc, options) {
@@ -1536,9 +1546,9 @@ class MessageHandler {
             .filter(line => line);
     }
 
-    prepareMessage(options, callback) {
+    async prepareMessageAsync(options) {
         if (options.prepared) {
-            return setImmediate(() => callback(null, options.prepared));
+            return options.prepared;
         }
 
         let id = new ObjectId();
@@ -1587,11 +1597,16 @@ class MessageHandler {
             subject
         };
 
-        return setImmediate(() => callback(null, prepared));
+        return prepared;
     }
 
-    // resolves or generates new thread id for a message
-    getThreadId(userId, subject, mimeTree, callback) {
+    prepareMessage(options, callback) {
+        this.prepareMessageAsync(options)
+            .then(prepared => callback(null, prepared))
+            .catch(err => callback(err));
+    }
+
+    async getThreadIdAsync(userId, subject, mimeTree) {
         let referenceIds = new Set(
             [
                 [].concat(mimeTree.parsedHeader['message-id'] || []).pop() || '',
@@ -1612,7 +1627,7 @@ class MessageHandler {
         referenceIds = Array.from(referenceIds).slice(0, 10);
 
         // most messages are not threaded, so an upsert call should be ok to make
-        this.database.collection('threads').findOneAndUpdate(
+        const existingThread = await this.database.collection('threads').findOneAndUpdate(
             {
                 user: userId,
                 ids: { $in: referenceIds },
@@ -1628,31 +1643,29 @@ class MessageHandler {
             },
             {
                 returnDocument: 'after'
-            },
-            (err, r) => {
-                if (err) {
-                    return callback(err);
-                }
-                if (r.value) {
-                    return callback(null, r.value._id);
-                }
-                // thread not found, create a new one
-                this.database.collection('threads').insertOne(
-                    {
-                        user: userId,
-                        subject,
-                        ids: referenceIds,
-                        updated: new Date()
-                    },
-                    (err, r) => {
-                        if (err) {
-                            return callback(err);
-                        }
-                        return callback(null, r.insertedId);
-                    }
-                );
             }
         );
+
+        if (existingThread.value) {
+            return existingThread.value._id;
+        }
+
+        // otherwise if no existing thread
+        const newThread = await this.database.collection('threads').insertOne({
+            user: userId,
+            subject,
+            ids: referenceIds,
+            updated: new Date()
+        });
+
+        return newThread.insertedId;
+    }
+
+    // resolves or generates new thread id for a message
+    getThreadId(userId, subject, mimeTree, callback) {
+        this.getThreadIdAsync(userId, subject, mimeTree)
+            .then(id => callback(null, id))
+            .catch(err => callback(err));
     }
 
     normalizeSubject(subject, options) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -663,7 +663,9 @@ class MessageHandler {
                             });
 
                             // do not use more suitable finally as it is not supported in Node v8
-                            processAudits().then(resolve(cleanupRes)).catch(resolve(cleanupRes));
+                            processAudits()
+                                .then(() => resolve(cleanupRes))
+                                .catch(() => resolve(cleanupRes));
                         }
                     );
                 });

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -183,7 +183,7 @@ class MessageHandler {
                     { upsert: true, projection: { _id: true } }
                 );
             }
-        } catch (err) {
+        } catch {
             // can ignore, not an important operation
         }
     }
@@ -720,12 +720,7 @@ class MessageHandler {
             return finishFunc();
         }
 
-        try {
-            await this.updateAddressRegister(mailboxData.user, addresses);
-            return finishFunc();
-        } catch (err) {
-            return finishFunc(err);
-        }
+        await this.updateAddressRegister(mailboxData.user, addresses);
     }
 
     async updateQuotaAsync(user, inc, options) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1639,6 +1639,7 @@ class MessageHandler {
             .catch(err => callback(err));
     }
 
+    // resolves or generates new thread id for a message
     async getThreadIdAsync(userId, subject, mimeTree) {
         let referenceIds = new Set(
             [
@@ -1692,13 +1693,6 @@ class MessageHandler {
         });
 
         return newThread.insertedId;
-    }
-
-    // resolves or generates new thread id for a message
-    getThreadId(userId, subject, mimeTree, callback) {
-        this.getThreadIdAsync(userId, subject, mimeTree)
-            .then(id => callback(null, id))
-            .catch(err => callback(err));
     }
 
     normalizeSubject(subject, options) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -196,12 +196,10 @@ class MessageHandler {
         }
 
         // get target mailbox data
-        let mailboxData = await this.getMailboxAsync(options);
+        // get target user data
+        let [mailboxData, userData] = await Promise.all([this.getMailboxAsync(options), this.users.collection('users').findOne({ _id: options.user })]);
 
         options.targetMailboxEncrypted = !!mailboxData.encryptMessages;
-
-        // get target user data
-        const userData = await this.users.collection('users').findOne({ _id: options.user });
 
         let prepared = options.prepared; // might be undefined
 
@@ -308,10 +306,11 @@ class MessageHandler {
             // with err, with attachments
             try {
                 await this.attachmentStorage.deleteMany(attachmentIds, maildata.magic);
-                throw err;
-            } catch (ignore) {
+            } catch {
+                // throw original error
                 throw err;
             }
+            throw err;
         };
 
         try {
@@ -474,9 +473,9 @@ class MessageHandler {
         }
 
         let rollback = async rollbackError => {
-            let args;
+            let r;
             try {
-                args = await this.users.collection('users').findOneAndUpdate(
+                r = await this.users.collection('users').findOneAndUpdate(
                     {
                         _id: mailboxData.user
                     },
@@ -492,11 +491,10 @@ class MessageHandler {
                         }
                     }
                 );
-            } catch (ignore) {
-                // ignore
+            } catch {
+                // some error, clean up immediately
+                return cleanup(rollbackError);
             }
-
-            let r = args && args[1];
 
             if (r && r.value) {
                 this.loggelf({
@@ -598,63 +596,7 @@ class MessageHandler {
         let uidValidity = mailboxData.uidValidity;
         let uid = messageData.uid;
 
-        if (
-            options.session &&
-            options.session.selected &&
-            options.session.selected.mailbox &&
-            options.session.selected.mailbox.toString() === mailboxData._id.toString()
-        ) {
-            options.session.writeStream.write(options.session.formatResponse('EXISTS', messageData.uid));
-        }
-
-        let updateAddressRegister = async finishFunc => {
-            let addresses = [];
-
-            if (messageData.junk || flags.includes('\\Draft')) {
-                // skip junk and draft messages
-                return finishFunc();
-            }
-
-            let parsed = messageData.mimeTree && messageData.mimeTree.parsedHeader;
-
-            if (parsed) {
-                let keyList = mailboxData.specialUse === '\\Sent' ? ['to', 'cc', 'bcc'] : ['from'];
-
-                for (const disallowedHeader of DISALLOWED_HEADERS_FOR_ADDRESS_REGISTER) {
-                    // if email contains headers that we do not want,
-                    // don't add any emails to address register
-                    if (parsed[disallowedHeader]) {
-                        return finishFunc();
-                    }
-                }
-
-                for (let key of keyList) {
-                    if (parsed[key] && parsed[key].length) {
-                        for (let addr of parsed[key]) {
-                            if (/no-?reply/i.test(addr.address)) {
-                                continue;
-                            }
-                            if (!addresses.some(a => a.address === addr.address)) {
-                                addresses.push(addr);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (!addresses.length) {
-                return finishFunc();
-            }
-
-            try {
-                await this.updateAddressRegister(mailboxData.user, addresses);
-                return finishFunc();
-            } catch (err) {
-                return finishFunc(err);
-            }
-        };
-
-        return updateAddressRegister(
+        const finishFunc = // finishFunc:
             async () =>
                 new Promise(resolve => {
                     this.notifier.addEntries(
@@ -681,45 +623,105 @@ class MessageHandler {
                                     .toArray();
 
                                 let now = new Date();
+                                const auditPromises = [];
+
                                 for (let auditData of audits) {
                                     if ((auditData.start && auditData.start > now) || (auditData.end && auditData.end < now)) {
                                         // audit not active
                                         continue;
                                     }
-                                    await this.auditHandler.store(auditData._id, raw, {
-                                        date: messageData.idate,
-                                        msgid: messageData.msgid,
-                                        header: messageData.mimeTree && messageData.mimeTree.parsedHeader,
-                                        ha: messageData.ha,
-                                        mailbox: mailboxData._id,
-                                        mailboxPath: mailboxData.path,
-                                        info: Object.assign({ queueId: messageData.outbound }, messageData.meta)
-                                    });
+
+                                    auditPromises.push(
+                                        this.auditHandler.store(auditData._id, raw, {
+                                            date: messageData.idate,
+                                            msgid: messageData.msgid,
+                                            header: messageData.mimeTree && messageData.mimeTree.parsedHeader,
+                                            ha: messageData.ha,
+                                            mailbox: mailboxData._id,
+                                            mailboxPath: mailboxData.path,
+                                            info: Object.assign({ queueId: messageData.outbound }, messageData.meta)
+                                        })
+                                    );
                                 }
+
+                                await Promise.all(auditPromises);
                             };
 
-                            let next = () =>
-                                cleanup(null, true, {
-                                    uidValidity,
-                                    uid,
-                                    id: messageData._id.toString(),
-                                    mailbox: mailboxData._id.toString(),
-                                    mailboxPath: mailboxData.path,
-                                    size,
-                                    status: 'new'
-                                });
+                            // can safely cleanup, no err given. Returns pending promise, which is fine
+                            const cleanupRes = cleanup(null, true, {
+                                uidValidity,
+                                uid,
+                                id: messageData._id.toString(),
+                                mailbox: mailboxData._id.toString(),
+                                mailboxPath: mailboxData.path,
+                                size,
+                                status: 'new'
+                            });
 
-                            // do not use more suitable .finally() as it is not supported in Node v8
+                            // do not use more suitable finally as it is not supported in Node v8
                             try {
                                 await processAudits();
-                                resolve(next());
-                            } catch (ignore) {
-                                resolve(next());
+                                resolve(cleanupRes);
+                            } catch {
+                                resolve(cleanupRes);
                             }
                         }
                     );
-                })
-        );
+                });
+
+        if (
+            options.session &&
+            options.session.selected &&
+            options.session.selected.mailbox &&
+            options.session.selected.mailbox.toString() === mailboxData._id.toString()
+        ) {
+            options.session.writeStream.write(options.session.formatResponse('EXISTS', messageData.uid));
+        }
+
+        let addresses = [];
+
+        if (messageData.junk || flags.includes('\\Draft')) {
+            // skip junk and draft messages
+            return finishFunc();
+        }
+
+        let parsed = messageData.mimeTree && messageData.mimeTree.parsedHeader;
+
+        if (parsed) {
+            let keyList = mailboxData.specialUse === '\\Sent' ? ['to', 'cc', 'bcc'] : ['from'];
+
+            for (const disallowedHeader of DISALLOWED_HEADERS_FOR_ADDRESS_REGISTER) {
+                // if email contains headers that we do not want,
+                // don't add any emails to address register
+                if (parsed[disallowedHeader]) {
+                    return finishFunc();
+                }
+            }
+
+            for (let key of keyList) {
+                if (parsed[key] && parsed[key].length) {
+                    for (let addr of parsed[key]) {
+                        if (/no-?reply/i.test(addr.address)) {
+                            continue;
+                        }
+                        if (!addresses.some(a => a.address === addr.address)) {
+                            addresses.push(addr);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!addresses.length) {
+            return finishFunc();
+        }
+
+        try {
+            await this.updateAddressRegister(mailboxData.user, addresses);
+            return finishFunc();
+        } catch (err) {
+            return finishFunc(err);
+        }
     }
 
     async updateQuotaAsync(user, inc, options) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1269,7 +1269,7 @@ class MessageHandler {
                     // message already encrypted, just continue move
                     return updateMessage();
                 } else {
-                    // not yet encrypted, need to encrypt
+                    // not yet encrypted, so need to encrypt
                     let res;
 
                     try {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -199,6 +199,10 @@ class MessageHandler {
         // get target user data
         let [mailboxData, userData] = await Promise.all([this.getMailboxAsync(options), this.users.collection('users').findOne({ _id: options.user })]);
 
+        if (!userData) {
+            throw new Error('No such user!');
+        }
+
         options.targetMailboxEncrypted = !!mailboxData.encryptMessages;
 
         let prepared = options.prepared; // might be undefined

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1015,6 +1015,7 @@ class MessageHandler {
         };
 
         let message = {};
+        // Loop through all moved messages
         while (message !== undefined) {
             try {
                 message = await cursor.next();

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1022,7 +1022,7 @@ class MessageHandler {
 
                 if (!message) {
                     await cursor.close(); // close cursor
-                    return done();
+                    return done(); // return move result
                 }
             } catch (err) {
                 return done(err);

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1184,11 +1184,11 @@ class MessageHandler {
                         err.code = 'StoreError';
 
                         await cursor.close();
-                        return await done(err);
+                        return done(err);
                     }
                 } catch (err) {
                     await cursor.close();
-                    return await done(err);
+                    return done(err);
                 }
 
                 let insertId = r.insertedId;
@@ -1207,7 +1207,7 @@ class MessageHandler {
                     );
                 } catch (err) {
                     await cursor.close();
-                    return await done(err);
+                    return done(err);
                 }
 
                 if (deleteMessageRes && deleteMessageRes.deletedCount) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1391,7 +1391,7 @@ class MessageHandler {
                 }
             } else {
                 // move target is not encrypted so proceed
-                updateMessage();
+                await updateMessage();
                 continue;
             }
         }

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1014,8 +1014,8 @@ class MessageHandler {
             return next();
         };
 
-        let processNext = async () => {
-            let message;
+        let message = {};
+        while (message !== undefined) {
             try {
                 message = await cursor.next();
 
@@ -1183,11 +1183,11 @@ class MessageHandler {
                         err.code = 'StoreError';
 
                         await cursor.close();
-                        return done(err);
+                        return await done(err);
                     }
                 } catch (err) {
                     await cursor.close();
-                    return done(err);
+                    return await done(err);
                 }
 
                 let insertId = r.insertedId;
@@ -1206,7 +1206,7 @@ class MessageHandler {
                     );
                 } catch (err) {
                     await cursor.close();
-                    return done(err);
+                    return await done(err);
                 }
 
                 if (deleteMessageRes && deleteMessageRes.deletedCount) {
@@ -1252,12 +1252,12 @@ class MessageHandler {
                                 removeEntries = [];
                                 existsEntries = [];
                                 this.notifier.fire(mailboxData.user);
-                                resolve(processNext());
+                                return resolve(true);
                             });
                         });
                     });
                 }
-                return processNext();
+                return true;
             };
 
             if (targetData.encryptMessages) {
@@ -1267,7 +1267,8 @@ class MessageHandler {
 
                 if (parsedContentType && parsedContentType.subtype === 'encrypted') {
                     // message already encrypted, just continue move
-                    return updateMessage();
+                    await updateMessage();
+                    continue;
                 } else {
                     // not yet encrypted, so need to encrypt
                     let res;
@@ -1281,7 +1282,8 @@ class MessageHandler {
                     // get user data
                     if (!res.pubKey) {
                         // no public key available, cannot encrypt
-                        return updateMessage();
+                        await updateMessage();
+                        continue;
                     }
 
                     // get raw from existing mimetree
@@ -1295,7 +1297,7 @@ class MessageHandler {
                     let chunks = [];
                     let chunklen = 0;
 
-                    return await new Promise((resolve, reject) => {
+                    await new Promise((resolve, reject) => {
                         outputStream
                             .on('readable', () => {
                                 let chunk;
@@ -1372,7 +1374,7 @@ class MessageHandler {
                                                     message.bodystructure = prepared.bodystructure;
                                                     message.envelope = prepared.envelope;
                                                     message.headers = prepared.headers;
-                                                    return resolve(updateMessage());
+                                                    return resolve(await updateMessage());
                                                 });
                                             })
                                         );
@@ -1380,18 +1382,18 @@ class MessageHandler {
                                         return reject(err); // inner promise rejects -> just in case reject the outer too
                                     }
                                 } else {
-                                    return resolve(updateMessage());
+                                    return resolve(await updateMessage());
                                 }
                             });
                     });
+                    continue;
                 }
             } else {
                 // move target is not encrypted so proceed
-                return updateMessage();
+                updateMessage();
+                continue;
             }
-        };
-
-        return processNext();
+        }
     }
 
     // NB! does not update user quota

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -962,58 +962,6 @@ class MessageHandler {
         let removeEntries = [];
         let existsEntries = [];
 
-        let done = async err => {
-            let next = () => {
-                if (err) {
-                    throw err;
-                }
-                return [
-                    true,
-                    {
-                        uidValidity: targetData.uidValidity,
-                        sourceUid,
-                        destinationUid,
-                        mailbox: mailboxData._id,
-                        target: targetData._id,
-                        status: 'moved'
-                    }
-                ];
-            };
-
-            if (sourceUid.length && options.showExpunged) {
-                options.session.writeStream.write({
-                    tag: '*',
-                    command: String(options.session.selected.uidList.length),
-                    attributes: [
-                        {
-                            type: 'atom',
-                            value: 'EXISTS'
-                        }
-                    ]
-                });
-            }
-
-            if (existsEntries.length) {
-                // mark messages as deleted from old mailbox
-                return await new Promise((resolve, reject) => {
-                    this.notifier.addEntries(mailboxData, removeEntries, () => {
-                        // mark messages as added to new mailbox
-                        this.notifier.addEntries(targetData, existsEntries, () => {
-                            this.notifier.fire(mailboxData.user);
-
-                            try {
-                                resolve(next()); // resolve with return value of next()
-                            } catch (err) {
-                                reject(err);
-                            }
-                        });
-                    });
-                });
-            }
-
-            return next();
-        };
-
         let message = {};
         // Loop through all moved messages
         while (message !== undefined) {
@@ -1022,10 +970,10 @@ class MessageHandler {
 
                 if (!message) {
                     await cursor.close(); // close cursor
-                    return done(); // return move result
+                    return this.moveDone(null, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options); // return move result
                 }
             } catch (err) {
-                return done(err);
+                return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options);
             }
 
             let messageId = message._id;
@@ -1060,11 +1008,15 @@ class MessageHandler {
 
                 if (!item || !item.value) {
                     await cursor.close();
-                    return done(new Error('Mailbox disappeared'));
+                    return this.moveDone(
+                        new Error('Mailbox disappeared'),
+                        { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries },
+                        options
+                    );
                 }
             } catch (err) {
                 await cursor.close();
-                return done(err);
+                return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options);
             }
 
             message._id = new ObjectId();
@@ -1172,95 +1124,6 @@ class MessageHandler {
                 }
             }
 
-            const updateMessage = async () => {
-                let r;
-
-                try {
-                    r = await this.database.collection('messages').insertOne(message, { writeConcern: 'majority' });
-
-                    if (!r || !r.acknowledged) {
-                        let err = new Error('Failed to store message [2]');
-                        err.responseCode = 500;
-                        err.code = 'StoreError';
-
-                        await cursor.close();
-                        return done(err);
-                    }
-                } catch (err) {
-                    await cursor.close();
-                    return done(err);
-                }
-
-                let insertId = r.insertedId;
-
-                // delete old message
-                let deleteMessageRes;
-
-                try {
-                    deleteMessageRes = await this.database.collection('messages').deleteOne(
-                        {
-                            _id: messageId,
-                            mailbox: mailboxData._id,
-                            uid: messageUid
-                        },
-                        { writeConcern: 'majority' }
-                    );
-                } catch (err) {
-                    await cursor.close();
-                    return done(err);
-                }
-
-                if (deleteMessageRes && deleteMessageRes.deletedCount) {
-                    if (options.session) {
-                        options.session.writeStream.write(options.session.formatResponse('EXPUNGE', sourceUid));
-                    }
-
-                    removeEntries.push({
-                        command: 'EXPUNGE',
-                        ignore: options.session && options.session.id,
-                        uid: messageUid,
-                        message: messageId,
-                        thread: message.thread,
-                        unseen,
-                        // modseq is needed to avoid updating mailbox entry
-                        modseq: newModseq
-                    });
-
-                    if (options.showExpunged) {
-                        options.session.writeStream.write(options.session.formatResponse('EXPUNGE', messageUid));
-                    }
-                }
-
-                let entry = {
-                    command: 'EXISTS',
-                    uid: uidNext,
-                    message: insertId,
-                    unseen: message.unseen,
-                    idate: message.idate,
-                    thread: message.thread
-                };
-                if (junk) {
-                    entry.junk = junk;
-                }
-                existsEntries.push(entry);
-
-                if (existsEntries.length >= consts.BULK_BATCH_SIZE) {
-                    // mark messages as deleted from old mailbox
-                    return new Promise(resolve => {
-                        this.notifier.addEntries(mailboxData, removeEntries, () => {
-                            // mark messages as added to new mailbox
-                            this.notifier.addEntries(targetData, existsEntries, () => {
-                                removeEntries = [];
-                                existsEntries = [];
-                                this.notifier.fire(mailboxData.user);
-                                return resolve(true);
-                            });
-                        });
-                    });
-                }
-                return true;
-            };
-
             if (targetData.encryptMessages) {
                 // move target mailbox is encrypted
                 const parsedHeader = (message.mimeTree && message.mimeTree.parsedHeader) || {};
@@ -1268,7 +1131,25 @@ class MessageHandler {
 
                 if (parsedContentType && parsedContentType.subtype === 'encrypted') {
                     // message already encrypted, just continue move
-                    await updateMessage();
+                    await this.updateMessage(
+                        {
+                            message,
+                            targetData,
+                            sourceUid,
+                            destinationUid,
+                            mailboxData,
+                            existsEntries,
+                            removeEntries,
+                            messageId,
+                            messageUid,
+                            unseen,
+                            newModseq,
+                            uidNext,
+                            junk
+                        },
+                        cursor,
+                        options
+                    );
                     continue;
                 } else {
                     // not yet encrypted, so need to encrypt
@@ -1277,13 +1158,31 @@ class MessageHandler {
                     try {
                         res = await this.users.collection('users').findOne({ _id: mailboxData.user });
                     } catch (err) {
-                        return done(err);
+                        return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options);
                     }
 
                     // get user data
                     if (!res.pubKey) {
                         // no public key available, cannot encrypt
-                        await updateMessage();
+                        await this.updateMessage(
+                            {
+                                message,
+                                targetData,
+                                sourceUid,
+                                destinationUid,
+                                mailboxData,
+                                existsEntries,
+                                removeEntries,
+                                messageId,
+                                messageUid,
+                                unseen,
+                                newModseq,
+                                uidNext,
+                                junk
+                            },
+                            cursor,
+                            options
+                        );
                         continue;
                     }
 
@@ -1291,7 +1190,11 @@ class MessageHandler {
                     let outputStream = this.indexer.rebuild(message.mimeTree); // get raw rebuilder response obj (.value is the stream)
 
                     if (!outputStream || outputStream.type !== 'stream' || !outputStream.value) {
-                        return done(new Error('Cannot fetch message'));
+                        return this.moveDone(
+                            new Error('Cannot fetch message'),
+                            { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries },
+                            options
+                        );
                     }
                     outputStream = outputStream.value; // set stream to actual stream object (.value)
 
@@ -1316,7 +1219,9 @@ class MessageHandler {
                                 try {
                                     encryptRes = await this.encryptMessageAsync(res.pubKey, raw);
                                 } catch (err) {
-                                    return reject(done(err));
+                                    return reject(
+                                        this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options)
+                                    );
                                 }
 
                                 // encrypt rebuilt raw
@@ -1328,7 +1233,9 @@ class MessageHandler {
                                     try {
                                         prepared = await this.prepareMessageAsync({ raw: encryptRes });
                                     } catch (err) {
-                                        return reject(done(err));
+                                        return reject(
+                                            this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options)
+                                        );
                                     }
 
                                     // prepare new message structure from encrypted raw
@@ -1375,7 +1282,28 @@ class MessageHandler {
                                                     message.bodystructure = prepared.bodystructure;
                                                     message.envelope = prepared.envelope;
                                                     message.headers = prepared.headers;
-                                                    return resolve(await updateMessage());
+
+                                                    return resolve(
+                                                        await this.updateMessage(
+                                                            {
+                                                                message,
+                                                                targetData,
+                                                                sourceUid,
+                                                                destinationUid,
+                                                                mailboxData,
+                                                                existsEntries,
+                                                                removeEntries,
+                                                                messageId,
+                                                                messageUid,
+                                                                unseen,
+                                                                newModseq,
+                                                                uidNext,
+                                                                junk
+                                                            },
+                                                            cursor,
+                                                            options
+                                                        )
+                                                    );
                                                 });
                                             })
                                         );
@@ -1383,7 +1311,27 @@ class MessageHandler {
                                         return reject(err); // inner promise rejects -> just in case reject the outer too
                                     }
                                 } else {
-                                    return resolve(await updateMessage());
+                                    return resolve(
+                                        await this.updateMessage(
+                                            {
+                                                message,
+                                                targetData,
+                                                sourceUid,
+                                                destinationUid,
+                                                mailboxData,
+                                                existsEntries,
+                                                removeEntries,
+                                                messageId,
+                                                messageUid,
+                                                unseen,
+                                                newModseq,
+                                                uidNext,
+                                                junk
+                                            },
+                                            cursor,
+                                            options
+                                        )
+                                    );
                                 }
                             });
                     });
@@ -1391,8 +1339,25 @@ class MessageHandler {
                 }
             } else {
                 // move target is not encrypted so proceed
-                await updateMessage();
-                continue;
+                await this.updateMessage(
+                    {
+                        message,
+                        targetData,
+                        sourceUid,
+                        destinationUid,
+                        mailboxData,
+                        existsEntries,
+                        removeEntries,
+                        messageId,
+                        messageUid,
+                        unseen,
+                        newModseq,
+                        uidNext,
+                        junk
+                    },
+                    cursor,
+                    options
+                );
             }
         }
     }
@@ -2092,6 +2057,159 @@ class MessageHandler {
             '--\r\n';
 
         return Buffer.concat([headers, breaker, Buffer.from(text)]);
+    }
+
+    async moveDone(err, data, options) {
+        let { sourceUid, existsEntries, mailboxData, removeEntries, targetData, destinationUid } = data;
+
+        // Show Expunged
+        if (sourceUid.length && options.showExpunged) {
+            options.session.writeStream.write({
+                tag: '*',
+                command: String(options.session.selected.uidList.length),
+                attributes: [
+                    {
+                        type: 'atom',
+                        value: 'EXISTS'
+                    }
+                ]
+            });
+        }
+
+        if (existsEntries.length) {
+            // mark messages as deleted from old mailbox
+            await new Promise(resolve => {
+                this.notifier.addEntries(mailboxData, removeEntries, () => {
+                    // mark messages as added to new mailbox
+                    this.notifier.addEntries(targetData, existsEntries, () => {
+                        this.notifier.fire(mailboxData.user);
+
+                        return resolve();
+                    });
+                });
+            });
+        }
+
+        if (err) {
+            throw err;
+        }
+
+        return [
+            true,
+            {
+                uidValidity: targetData.uidValidity,
+                sourceUid,
+                destinationUid,
+                mailbox: mailboxData._id,
+                target: targetData._id,
+                status: 'moved'
+            }
+        ];
+    }
+
+    async updateMessage(data, cursor, options) {
+        let r;
+
+        let {
+            message,
+            targetData,
+            sourceUid,
+            destinationUid,
+            mailboxData,
+            existsEntries,
+            removeEntries,
+            messageId,
+            messageUid,
+            unseen,
+            newModseq,
+            uidNext,
+            junk
+        } = data;
+
+        try {
+            r = await this.database.collection('messages').insertOne(message, { writeConcern: 'majority' });
+
+            if (!r || !r.acknowledged) {
+                let err = new Error('Failed to store message [2]');
+                err.responseCode = 500;
+                err.code = 'StoreError';
+
+                await cursor.close();
+                return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options); // will throw
+            }
+        } catch (err) {
+            await cursor.close();
+            return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options); // will throw
+        }
+
+        let insertId = r.insertedId;
+
+        // delete old message
+        let deleteMessageRes;
+
+        try {
+            deleteMessageRes = await this.database.collection('messages').deleteOne(
+                {
+                    _id: messageId,
+                    mailbox: mailboxData._id,
+                    uid: messageUid
+                },
+                { writeConcern: 'majority' }
+            );
+        } catch (err) {
+            await cursor.close();
+            return this.moveDone(err, { targetData, sourceUid, destinationUid, mailboxData, existsEntries, removeEntries }, options); // will throw
+        }
+
+        if (deleteMessageRes && deleteMessageRes.deletedCount) {
+            if (options.session) {
+                options.session.writeStream.write(options.session.formatResponse('EXPUNGE', sourceUid));
+            }
+
+            removeEntries.push({
+                command: 'EXPUNGE',
+                ignore: options.session && options.session.id,
+                uid: messageUid,
+                message: messageId,
+                thread: message.thread,
+                unseen,
+                // modseq is needed to avoid updating mailbox entry
+                modseq: newModseq
+            });
+
+            if (options.showExpunged) {
+                options.session.writeStream.write(options.session.formatResponse('EXPUNGE', messageUid));
+            }
+        }
+
+        let entry = {
+            command: 'EXISTS',
+            uid: uidNext,
+            message: insertId,
+            unseen: message.unseen,
+            idate: message.idate,
+            thread: message.thread
+        };
+        if (junk) {
+            entry.junk = junk;
+        }
+        existsEntries.push(entry);
+
+        if (existsEntries.length >= consts.BULK_BATCH_SIZE) {
+            // mark messages as deleted from old mailbox
+            return new Promise(resolve => {
+                this.notifier.addEntries(mailboxData, removeEntries, () => {
+                    // mark messages as added to new mailbox
+                    this.notifier.addEntries(targetData, existsEntries, () => {
+                        removeEntries = [];
+                        existsEntries = [];
+                        this.notifier.fire(mailboxData.user);
+                        return resolve(true);
+                    });
+                });
+            });
+        }
+        return true;
     }
 }
 


### PR DESCRIPTION
1. Rewrite add message. Add `addAsync` rewrite `add` to use async/await.
2. Rewrite move messages. Add `moveAsync` rewrite `move` to use async/await.

Previously they were fully callback based, which made it harder to read and understand. Current changes should have improved the readibility as it made code more linear.
There are still some function-in-function spots, that may be fixed with later commits and more thorough refactoring.