### PR TITLE
ZMS-171: Add support for an outbound MTA relay

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -3981,7 +3981,8 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         to: envelope.to,
                         sendTime,
                         origin: options.origin || options.ip,
-                        runPlugins: true
+                        runPlugins: true,
+                        mtaRelay: userData.mtaRelay || false
                     },
                     (err, ...args) => {
                         if (err || !args[0]) {

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -2634,6 +2634,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let message = result.value.message;
 
             let messageData;
+            let userData;
             try {
                 messageData = await db.database.collection('messages').findOne(
                     {
@@ -2650,6 +2651,18 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                             'meta.to': true,
                             mimeTree: true,
                             forwardTargets: true
+                        }
+                    }
+                );
+
+                userData = await db.database.collection('users').findOne(
+                    {
+                        _id: user
+                    },
+                    {
+                        projection: {
+                            _id: true,
+                            mtaRelay: true
                         }
                     }
                 );
@@ -2705,7 +2718,8 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 sender: messageData.meta.from,
                 recipient: messageData.meta.to,
                 targets: forwardTargets,
-                stream: response.value
+                stream: response.value,
+                userData
             };
 
             let queueId;

--- a/lib/api/submit.js
+++ b/lib/api/submit.js
@@ -58,7 +58,8 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
                     pubKey: true,
                     disabled: true,
                     suspended: true,
-                    fromWhitelist: true
+                    fromWhitelist: true,
+                    mtaRelay: true
                 }
             },
             (err, userData) => {
@@ -472,7 +473,8 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
                                                         to: compiledEnvelope.to,
                                                         sendTime,
                                                         origin: options.ip,
-                                                        runPlugins: true
+                                                        runPlugins: true,
+                                                        mtaRelay: userData.mtaRelay || false
                                                     },
                                                     (err, ...args) => {
                                                         if (err || !args[0]) {

--- a/lib/api/users.js
+++ b/lib/api/users.js
@@ -352,6 +352,14 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                             'An array of forwarding targets. The value could either be an email address or a relay url to next MX server ("smtp://mx2.zone.eu:25") or an URL where mail contents are POSTed to'
                         ),
 
+                    mtaRelay: Joi.string()
+                        .uri({
+                            scheme: [/smtps?/],
+                            allowRelative: false,
+                            relativeOnly: false
+                        })
+                        .description('An address of an SMTP MTA relay. The value should be a relay url. If specified uses the this relay as the outbound MTA.'),
+
                     spamLevel: Joi.number()
                         .min(0)
                         .max(100)
@@ -500,6 +508,7 @@ module.exports = (db, server, userHandler, settingsHandler) => {
             let values = permission.filter(result.value);
 
             let targets = values.targets;
+            let mtaRelay = values.mtaRelay;
 
             if (targets) {
                 for (let i = 0, len = targets.length; i < len; i++) {
@@ -533,6 +542,15 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                 }
 
                 values.targets = targets;
+            }
+
+            if (mtaRelay && /^smtps?:/i.test(mtaRelay)) {
+                mtaRelay = {
+                    id: new ObjectId(),
+                    type: 'relay',
+                    value: mtaRelay // current mtaRelay string value
+                };
+                values.mtaRelay = mtaRelay;
             }
 
             if ('pubKey' in req.params && !values.pubKey) {
@@ -796,6 +814,7 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                                 .required()
                                 .description('Custom internal metadata object set for this user. Not available for user-role tokens'),
                             targets: Joi.array().items(Joi.string()).required().description('List of forwarding targets'),
+                            mtaRelay: Joi.string().required().description('MTA Relay url'),
                             spamLevel: Joi.number()
                                 .required()
                                 .description('Relative scale for detecting spam. 0 means that everything is spam, 100 means that nothing is spam'),
@@ -1073,6 +1092,8 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                         .map(target => target.value)
                         .filter(target => target),
 
+                    mtaRelay: userData.mtaRelay?.value || false,
+
                     limits: {
                         quota: {
                             allowed: Number(userData.quota) || settings['const:max:storage'],
@@ -1193,6 +1214,14 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                         .description(
                             'An array of forwarding targets. The value could either be an email address or a relay url to next MX server ("smtp://mx2.zone.eu:25") or an URL where mail contents are POSTed to'
                         ),
+
+                    mtaRelay: Joi.string()
+                        .uri({
+                            scheme: [/smtps?/],
+                            allowRelative: false,
+                            relativeOnly: false
+                        })
+                        .description('An address of an SMTP MTA relay. The value should be a relay url. If specified uses the this relay as the outbound MTA.'),
 
                     spamLevel: Joi.number()
                         .min(0)
@@ -1326,6 +1355,7 @@ module.exports = (db, server, userHandler, settingsHandler) => {
 
             let targets = values.targets;
             let existingTargets;
+            let mtaRelay = values.mtaRelay;
 
             if (targets) {
                 for (let i = 0, len = targets.length; i < len; i++) {
@@ -1380,6 +1410,15 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                         code: 'InternalDatabaseError'
                     });
                 }
+            }
+
+            if (mtaRelay && /^smtps?:/i.test(mtaRelay)) {
+                mtaRelay = {
+                    id: new ObjectId(),
+                    type: 'relay',
+                    value: mtaRelay // current mtaRelay string value
+                };
+                values.mtaRelay = mtaRelay;
             }
 
             if (!values.name && 'name' in req.params) {

--- a/lib/autoreply.js
+++ b/lib/autoreply.js
@@ -101,7 +101,8 @@ async function autoreply(options, autoreplyData) {
                                 reason: 'autoreply',
                                 from: '',
                                 to: options.sender,
-                                interface: 'autoreplies'
+                                interface: 'autoreplies',
+                                mtaRelay: options.userData?.mtaRelay || false
                             },
                             (err, ...args) => {
                                 if (err || !args[0]) {

--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -74,7 +74,8 @@ class FilterHandler {
             encryptForwarded: true,
             pubKey: true,
             spamLevel: true,
-            tagsview: true
+            tagsview: true,
+            mtaRelay: true
         };
 
         if (collection === 'users') {

--- a/lib/forward.js
+++ b/lib/forward.js
@@ -13,7 +13,9 @@ module.exports = (options, callback) => {
 
         targets: options.targets,
 
-        interface: 'forwarder'
+        interface: 'forwarder',
+
+        mtaRelay: options.userData?.mtaRelay || false
     };
 
     let message = options.maildrop.push(mail, (err, ...args) => {

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -195,6 +195,25 @@ class Maildropper {
             });
         }
 
+        if (options.mtaRelay) {
+            let relayData = options.mtaRelay.value;
+            if (typeof relayData === 'string') {
+                relayData = tools.getRelayData(relayData);
+            }
+
+            envelope.to.forEach(to => {
+                deliveries.push({
+                    to,
+                    mx: relayData.mx,
+                    mxPort: relayData.mxPort,
+                    mxAuth: relayData.mxAuth,
+                    mxSecure: relayData.mxSecure,
+                    skipSRS: true,
+                    skipSTS: true
+                });
+            });
+        }
+
         if (!deliveries.length) {
             deliveries = envelope.to.map(to => ({
                 to

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -144,16 +144,42 @@ class Maildropper {
 
         let deliveries = [];
 
+        let mxData = false;
+
+        if (options.mtaRelay) {
+            // user has MTA Relay set, use it to send outbound email
+            let relayData = options.mtaRelay.value;
+            if (typeof relayData === 'string') {
+                relayData = tools.getRelayData(relayData);
+            }
+
+            mxData = {
+                mx: relayData.mx,
+                mxPort: relayData.mxPort,
+                mxAuth: relayData.mxAuth,
+                mxSecure: relayData.mxSecure,
+                skipSRS: true,
+                skipSTS: true
+            };
+        }
+
         if (options.targets) {
             options.targets.forEach(target => {
                 switch (target.type) {
                     case 'mail':
-                        deliveries.push({
-                            to: target.value,
-                            forwardedFor: target.recipient
-                        });
-                        break;
+                        {
+                            let delivery = {
+                                to: target.value,
+                                forwardedFor: target.recipient
+                            };
 
+                            if (mxData) {
+                                delivery = { ...delivery, ...mxData };
+                            }
+
+                            deliveries.push(delivery);
+                        }
+                        break;
                     case 'relay':
                         {
                             let recipients = new Set([].concat(options.to || []).concat(target.recipient || []));
@@ -195,29 +221,16 @@ class Maildropper {
             });
         }
 
-        if (options.mtaRelay) {
-            let relayData = options.mtaRelay.value;
-            if (typeof relayData === 'string') {
-                relayData = tools.getRelayData(relayData);
-            }
-
-            envelope.to.forEach(to => {
-                deliveries.push({
-                    to,
-                    mx: relayData.mx,
-                    mxPort: relayData.mxPort,
-                    mxAuth: relayData.mxAuth,
-                    mxSecure: relayData.mxSecure,
-                    skipSRS: true,
-                    skipSTS: true
-                });
-            });
-        }
-
         if (!deliveries.length) {
-            deliveries = envelope.to.map(to => ({
-                to
-            }));
+            deliveries = envelope.to.map(to => {
+                let delivery = { to };
+
+                if (mxData) {
+                    delivery = { ...delivery, ...mxData };
+                }
+
+                return delivery;
+            });
         }
 
         if (!deliveries.length) {

--- a/setup/09_install_zone_mta.sh
+++ b/setup/09_install_zone_mta.sh
@@ -61,7 +61,7 @@ secret=\"$ZONEMTA_SECRET\"
 algo=\"md5\"" > /etc/zone-mta/plugins/loop-breaker.toml
 
 echo "[wildduck]
-enabled=[\"receiver\", \"sender\"]
+enabled=[\"receiver\", \"sender\", \"main\"]
 
 # which interfaces this plugin applies to
 interfaces=[\"feeder\"]


### PR DESCRIPTION
Add support for an outbound MTA relay.

A user can specify a MTA relay in a form of `smtp://<user>:<pass>@smtp.domain.tld:<port|587,465,25>`.
In case a MTA relay is specified it will be used to send outbound email instead.
That is currently used MTA (Zone-MTA) will relay the outbound email to that MTA Relay
and then that Relay is responsible for delivering the email.

Related PRs:
1. https://github.com/nodemailer/zonemta-wildduck/pull/35
2. https://github.com/zone-eu/zone-mta/pull/439
3. https://github.com/nodemailer/haraka-plugin-wildduck/pull/56

It made sense to add the required routing information during the `queue:route` hook invocation
and then Zone-MTA uses that info to relay the email to specified MTA relay.