### PR TITLE
ZMS-215: fix incorrect existsEntries and removeEntries clearing in updateMessage()

### DIFF
--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -197,6 +197,7 @@ class MessageHandler {
 
         // get target mailbox data
         // get target user data
+        // if throws will be handled by caller or wrapper
         let [mailboxData, userData] = await Promise.all([this.getMailboxAsync(options), this.users.collection('users').findOne({ _id: options.user })]);
 
         if (!userData) {
@@ -2201,8 +2202,8 @@ class MessageHandler {
                 this.notifier.addEntries(mailboxData, removeEntries, () => {
                     // mark messages as added to new mailbox
                     this.notifier.addEntries(targetData, existsEntries, () => {
-                        removeEntries = [];
-                        existsEntries = [];
+                        removeEntries.length = 0;
+                        existsEntries.length = 0;
                         this.notifier.fire(mailboxData.user);
                         return resolve(true);
                     });


### PR DESCRIPTION
Fix incorrect existsEntries and removeEntries clearing in updateMessage()
in message-handler.js.
Incorrect clearing (clearing was not happening at all) caused the entries to pile
up and the addEntries() method to incorrectly insert the journal entries one by
one, causing a huge spike in DB Inserts.
This PR fixes the issue.