### PR TITLE
ZMS-222: use moveAsync and addAsync directly where possible

### DIFF
--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -63,26 +63,6 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
     const getMailboxCounter = util.promisify(tools.getMailboxCounter);
     const asyncForward = util.promisify(forward);
 
-    const addMessage = util.promisify((...args) => {
-        let callback = args.pop();
-        messageHandler.add(...args, (err, status, data) => {
-            if (err) {
-                return callback(err);
-            }
-            return callback(null, { status, data });
-        });
-    });
-
-    const moveMessage = util.promisify((...args) => {
-        let callback = args.pop();
-        messageHandler.move(...args, (err, result, info) => {
-            if (err) {
-                return callback(err);
-            }
-            return callback(null, { result, info });
-        });
-    });
-
     const addThreadCountersToMessageList = async (user, list) => {
         const threadIdsToCount = list.map(message => message.thread);
         const threadCounts = await db.database
@@ -269,7 +249,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             }
 
             try {
-                let data = await moveMessage({
+                const data = await messageHandler.moveAsync({
                     user,
                     source: { user, mailbox },
                     destination: { user, mailbox: moveTo },
@@ -2464,7 +2444,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
             let status, messageData;
             try {
-                let resp = await addMessage({
+                const resp = await messageHandler.addAsync({
                     user,
                     mailbox: mailboxData,
                     meta: {
@@ -3030,7 +3010,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
             if (queueId) {
                 response.queueId = queueId;
-                let moved = await moveMessage({
+                const moved = await messageHandler.moveAsync({
                     user,
                     source: {
                         user: messageData.user,

--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -17,16 +17,6 @@ class FilterHandler {
         this.prepareMessage = util.promisify(this.messageHandler.prepareMessage.bind(this.messageHandler));
         this.encryptMessage = util.promisify(this.messageHandler.encryptMessage.bind(this.messageHandler));
 
-        this.addMessage = util.promisify((...args) => {
-            let callback = args.pop();
-            this.messageHandler.add(...args, (err, status, data) => {
-                if (err) {
-                    return callback(err);
-                }
-                return callback(null, { status, data });
-            });
-        });
-
         this.ttlcounter = util.promisify(this.messageHandler.counters.ttlcounter.bind(this.messageHandler.counters));
         this.forward = util.promisify(forward);
 
@@ -702,7 +692,7 @@ class FilterHandler {
         }
 
         try {
-            let { data } = await this.addMessage(messageOpts);
+            const { data } = await this.messageHandler.addAsync(messageOpts); // returns {status, data}
             if (data) {
                 filterResults.push({
                     mailbox: data.mailbox && data.mailbox.toString(),

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -131,7 +131,7 @@ class MessageHandler {
 
     add(options, callback) {
         this.addAsync(options)
-            .then(messageAddedData => callback(null, ...messageAddedData))
+            .then(messageAddedData => callback(null, messageAddedData.status, messageAddedData.data))
             .catch(err => callback(err));
     }
 
@@ -299,7 +299,7 @@ class MessageHandler {
         let cleanup = async (err, status, data) => {
             if (!err) {
                 // no error
-                return [status, data];
+                return { status, data };
             }
 
             let attachmentIds = Object.keys(mimeTree.attachmentMap || {}).map(key => mimeTree.attachmentMap[key]);
@@ -917,7 +917,7 @@ class MessageHandler {
 
     move(options, callback) {
         this.moveAsync(options)
-            .then(movedMessageRes => callback(null, ...movedMessageRes))
+            .then(movedMessageRes => callback(null, movedMessageRes.result, movedMessageRes.info))
             .catch(err => callback(err));
     }
 
@@ -2095,9 +2095,9 @@ class MessageHandler {
             throw err;
         }
 
-        return [
-            true,
-            {
+        return {
+            result: true,
+            info: {
                 uidValidity: targetData.uidValidity,
                 sourceUid,
                 destinationUid,
@@ -2105,7 +2105,7 @@ class MessageHandler {
                 target: targetData._id,
                 status: 'moved'
             }
-        ];
+        };
     }
 
     async updateMessage(data, cursor, options) {

--- a/lib/tasks/search-apply.js
+++ b/lib/tasks/search-apply.js
@@ -10,7 +10,6 @@ const ObjectId = require('mongodb').ObjectId;
 let run = async (task, data, options) => {
     const messageHandler = options.messageHandler;
 
-    const moveMessage = util.promisify(messageHandler.move.bind(messageHandler));
     const updateMessage = util.promisify(messageHandler.update.bind(messageHandler));
 
     let updated = 0;
@@ -62,7 +61,7 @@ let run = async (task, data, options) => {
 
             if (action.moveTo && action.moveTo.toString() !== messageData.mailbox.toString()) {
                 try {
-                    await moveMessage({
+                    await messageHandler.moveAsync({
                         user,
                         source: {
                             user: messageData.user,

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -3729,7 +3729,6 @@ class UserHandler {
         }
 
         let encryptMessage = util.promisify(this.messageHandler.encryptMessage.bind(this.messageHandler));
-        let addMessage = util.promisify(this.messageHandler.add.bind(this.messageHandler));
 
         for (let data of messages) {
             let compiler = new MailComposer(data);
@@ -3759,7 +3758,7 @@ class UserHandler {
                     message = encrypted;
                 }
 
-                await addMessage({
+                await this.messageHandler.addAsync({
                     user: userData._id,
                     [mailboxQueryKey]: mailboxQueryValue,
                     meta: {


### PR DESCRIPTION
Instead of wrapping callback based add and move functions for messages - use moveAsync and addAsync directly where possible.