### PR TITLE
ZMS-229: Check for correct mongopaging cursor

### DIFF
--- a/lib/mongopaging-find-wrapper.js
+++ b/lib/mongopaging-find-wrapper.js
@@ -9,6 +9,30 @@ const mongopagingFindWrapper = async (collection, opts) => {
     const pageNextOriginalCursor = getCursorFromCursorWrapper(opts.next);
     const pagePrevOriginalCursor = getCursorFromCursorWrapper(opts.previous);
 
+    if (opts.paginatedField && opts.paginatedField !== '_id') {
+        // If the paginatedField is not just _id the the cursor is expected to be an array of 2 elements
+        // applies to both cursors
+
+        for (const pageOriginalCursor of [pagePrevOriginalCursor, pageNextOriginalCursor]) {
+            const cursorData = getCursorDataFromCursor(pageOriginalCursor);
+
+            if (pageOriginalCursor && cursorData) {
+                if (!Array.isArray(cursorData)) {
+                    const err = new Error('Invalid paging cursor');
+                    err.code = 'cursorerr';
+                    throw err;
+                }
+
+                if (cursorData.length < 2) {
+                    // only 1 element
+                    const err = new Error('Invalid paging cursor');
+                    err.code = 'cursorerr';
+                    throw err;
+                }
+            }
+        }
+    }
+
     if (pageNextOriginalCursor) {
         // Have next cursor
         const pageFromNextCursor = getPageFromMongopagingCursor(opts.next);
@@ -103,9 +127,17 @@ function getCursorFromCursorWrapper(cursorWrapperString) {
     }
 }
 
+function getCursorDataFromCursor(cursorString) {
+    if (!cursorString) {
+        return false;
+    }
+    return EJSON.parse(Buffer.from(cursorString, 'base64url').toString());
+}
+
 module.exports = {
     mongopagingFindWrapper,
     getPageFromMongopagingCursor,
     setPageToMongopagingCursor,
-    getCursorFromCursorWrapper
+    getCursorFromCursorWrapper,
+    getCursorDataFromCursor
 };


### PR DESCRIPTION
If the only paginated field is `_id` then the cursor is of shorter format. But in any other case (`paginatedField` is anything other than `_id`) the decoded cursor is an array of 2 values. Check for length of decoded cursor and that it is an array in case the `paginatedField` is not an `_id`. If it is `_id` then allow shorter cursor