### PR TITLE
ZMS-216: add logs for debugging timeout issue

### DIFF
--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -155,6 +155,14 @@ class FilterHandler {
             });
         }
 
+        this.loggelf({
+            short_message: '[FILTER-HANDLER] Prepared Message',
+            _user: userData._id.toString(),
+            _sender: sender,
+            _recipient: recipient,
+            _message_id: prepared.mimeTree.parsedHeader['message-id']
+        });
+
         prepared.mimeTree.header.unshift('Return-Path: <' + Buffer.from(sender).toString('binary') + '>');
         prepared.mimeTree.header.unshift('Delivered-To: ' + Buffer.from(recipient).toString('binary'));
 
@@ -227,6 +235,14 @@ class FilterHandler {
             // ignore as filters are not so importand
         }
 
+        this.loggelf({
+            short_message: '[FILTER-HANDLER] Got User Filters',
+            _user: userData._id.toString(),
+            _sender: sender,
+            _recipient: recipient,
+            _message_id: prepared.mimeTree.parsedHeader['message-id']
+        });
+
         let isEncrypted = false;
         let forwardTargets = new Map();
 
@@ -267,6 +283,14 @@ class FilterHandler {
             }
         }
 
+        this.loggelf({
+            short_message: '[FILTER-HANDLER] Checked Global Whitelist/Blacklist',
+            _user: userData._id.toString(),
+            _sender: sender,
+            _recipient: recipient,
+            _message_id: prepared.mimeTree.parsedHeader['message-id']
+        });
+
         for (let filterData of filters) {
             if (!(await checkFilter(filterData, prepared, maildata))) {
                 continue;
@@ -289,6 +313,14 @@ class FilterHandler {
                 }
             });
         }
+
+        this.loggelf({
+            short_message: '[FILTER-HANDLER] Checked Filters',
+            _user: userData._id.toString(),
+            _sender: sender,
+            _recipient: recipient,
+            _message_id: prepared.mimeTree.parsedHeader['message-id']
+        });
 
         if (typeof userData.spamLevel === 'number' && userData.spamLevel >= 0) {
             let isSpam;
@@ -520,7 +552,21 @@ class FilterHandler {
         let outbound = [];
 
         try {
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] Before Forward',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             let forwardId = await forwardMessage();
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] After Forward',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             if (forwardId) {
                 filterResults.push({
                     forward: Array.from(forwardTargets)
@@ -556,7 +602,21 @@ class FilterHandler {
         }
 
         try {
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] Before Autoreply',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             let autoreplyId = await sendAutoreply();
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] After Autoreply',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             if (autoreplyId) {
                 filterResults.push({ autoreply: sender, 'autoreply-queue-id': autoreplyId });
                 outbound.push(autoreplyId);
@@ -596,6 +656,14 @@ class FilterHandler {
             } catch (err) {
                 log.error('Filter', '%s AUDITFAIL from=%s to=%s error=%s', prepared.id.toString(), '<>', sender, err.message);
             }
+
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] After Audits',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             return {
                 response: {
                     userData,
@@ -676,6 +744,13 @@ class FilterHandler {
         }
 
         if (userData.encryptMessages && userData.pubKey) {
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] Before Encryption',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             await encryptMessage();
             if (isEncrypted) {
                 // make sure we have the updated message structure values
@@ -692,7 +767,21 @@ class FilterHandler {
         }
 
         try {
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] Before Adding Message',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             const { data } = await this.messageHandler.addAsync(messageOpts); // returns {status, data}
+            this.loggelf({
+                short_message: '[FILTER-HANDLER] After Adding Message',
+                _user: userData._id.toString(),
+                _sender: sender,
+                _recipient: recipient,
+                _message_id: prepared.mimeTree.parsedHeader['message-id']
+            });
             if (data) {
                 filterResults.push({
                     mailbox: data.mailbox && data.mailbox.toString(),

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -200,6 +200,13 @@ class MessageHandler {
         // if throws will be handled by caller or wrapper
         let [mailboxData, userData] = await Promise.all([this.getMailboxAsync(options), this.users.collection('users').findOne({ _id: options.user })]);
 
+        this.loggelf({
+            short_message: '[MESSAGE-HANDLER] Got Mailbox and User Data',
+            _user: mailboxData.user,
+            _sess: options.session && options.session.id,
+            _mailbox: mailboxData._id
+        });
+
         if (!userData) {
             throw new Error('No such user!');
         }
@@ -239,6 +246,13 @@ class MessageHandler {
                 alreadyEncrypted = true;
             }
         }
+
+        this.loggelf({
+            short_message: '[MESSAGE-HANDLER] Checked if Encrypted',
+            _user: mailboxData.user,
+            _sess: options.session && options.session.id,
+            _mailbox: mailboxData._id
+        });
 
         let flags = Array.isArray(options.flags) ? options.flags : [].concat(options.flags || []);
 
@@ -283,6 +297,13 @@ class MessageHandler {
             prepared = newPrepared;
         }
 
+        this.loggelf({
+            short_message: '[MESSAGE-HANDLER] Got New Prepared',
+            _user: mailboxData.user,
+            _sess: options.session && options.session.id,
+            _mailbox: mailboxData._id
+        });
+
         let id = prepared.id;
         let mimeTree = prepared.mimeTree;
         let size = prepared.size;
@@ -326,6 +347,13 @@ class MessageHandler {
                     }
                     return resolve();
                 });
+            });
+
+            this.loggelf({
+                short_message: '[MESSAGE-HANDLER] Stored Initial Node Bodies',
+                _user: mailboxData.user,
+                _sess: options.session && options.session.id,
+                _mailbox: mailboxData._id
             });
         } catch (err) {
             return cleanup(err);


### PR DESCRIPTION
There seems to be a `wildduck plugin timeout` issue in Haraka Plugin Wildduck. Which has currently been traced down to Filter Handler's `storeMessage`. Locally this issue is extremely difficult to reproduce. New logs are added in order do trace exact piece of code that presumably times out. Will be removed in a future release when the issue has been resolved.