### PR TITLE
ZMS-255: do not return * 0 EXISTS if no messages expunged

### DIFF
--- a/lib/handlers/on-expunge.js
+++ b/lib/handlers/on-expunge.js
@@ -136,7 +136,7 @@ module.exports = (server, messageHandler) => (mailbox, update, session, callback
 
                             return cursor.close(() => {
                                 server.notifier.fire(session.user.id);
-                                if (!update.silent && session && session.selected && session.selected.uidList) {
+                                if (!update.silent && session && session.selected && session.selected.uidList && logdata._deleted) {
                                     session.writeStream.write({
                                         tag: '*',
                                         command: String(session.selected.uidList.length),


### PR DESCRIPTION
For client compatability in case no messages were deleted during expunge return no * 0 EXISTS.
`logdata._deleted` is used to log how many entries were deleted, but it can be used as sort of a deleted counter as well. In case the counter is 0 that means no messages were deleted/expunged and thus we return no * 0 EXISTS 

fixes #850