### PR TITLE
ZMS-268: add new addressregister endpoint to disable an entry or edit it

### DIFF
--- a/indexes.yaml
+++ b/indexes.yaml
@@ -419,6 +419,14 @@ indexes:
               name: 1
               updated: -1
 
+    - collection: addressregister
+      index:
+          name: by_disabled
+          key:
+              user: 1
+              disabled: 1
+              updated: -1
+
     # indexes for deleted messages
     - collection: archived
       index:

--- a/lib/api/addresses.js
+++ b/lib/api/addresses.js
@@ -1413,7 +1413,8 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                                         $options: 'i'
                                     }
                                 }
-                            ]
+                            ],
+                            disabled: false // get addresses that are not disabled
                         },
                         {
                             sort: { updated: -1 },
@@ -1456,6 +1457,147 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                         address: addressData.address
                     };
                 })
+            });
+        })
+    );
+
+    server.put(
+        {
+            path: '/users/:user/addressregister/:id',
+            summary: 'Update an address in the addressregister',
+            name: 'updateAddressAddressregister',
+            tags: ['Addresses'],
+            validationObjs: {
+                requestBody: {
+                    disabled: booleanSchema
+                        .required()
+                        .description(
+                            'Disable the address in the register. Disabled addresses are not updated on email receival and sending. Disabled addresses are not included in the response for listing addresses in the register.'
+                        ),
+                    name: Joi.string().max(255).description('Address header name')
+                },
+                queryParams: {
+                    sess: sessSchema,
+                    ip: sessIPSchema
+                },
+                pathParams: {
+                    user: userId,
+                    id: addressId
+                },
+                response: {
+                    200: {
+                        description: 'Success',
+                        model: Joi.object({
+                            success: successRes
+                        }).$_setFlag('objectName', 'SuccessResponse')
+                    }
+                }
+            }
+        },
+        tools.responseWrapper(async (req, res) => {
+            res.charSet('utf-8');
+
+            const { pathParams, requestBody, queryParams } = req.route.spec.validationObjs;
+
+            const schema = Joi.object({
+                ...pathParams,
+                ...queryParams,
+                ...requestBody
+            });
+
+            const result = schema.validate(req.params, {
+                abortEarly: false,
+                convert: true
+            });
+
+            if (result.error) {
+                res.status(400);
+                return res.json({
+                    error: result.error.message,
+                    code: 'InputValidationError',
+                    details: tools.validationErrors(result)
+                });
+            }
+
+            let user = new ObjectId(result.value.user);
+            let addressId = new ObjectId(result.value.id);
+
+            // permissions check
+            let permission;
+            if (req.user && req.user === result.value.user) {
+                permission = roles.can(req.role).readOwn('addresses');
+            } else {
+                permission = roles.can(req.role).readAny('addresses');
+            }
+
+            // permissions check
+            req.validate(permission);
+
+            let userData;
+            try {
+                userData = await db.users.collection('users').findOne(
+                    {
+                        _id: user
+                    },
+                    {
+                        projection: {
+                            _id: true,
+                            name: true,
+                            address: true
+                        }
+                    }
+                );
+            } catch (err) {
+                res.status(500);
+                return res.json({
+                    error: 'MongoDB Error: ' + err.message,
+                    code: 'InternalDatabaseError'
+                });
+            }
+
+            if (!userData) {
+                res.status(404);
+                return res.json({
+                    error: 'This user does not exist',
+                    code: 'UserNotFound'
+                });
+            }
+
+            const update = {
+                disabled: result.value.disabled,
+                updated: new Date()
+            };
+
+            if (result.value.name) {
+                update.name = result.value.name;
+                try {
+                    // try to decode
+                    update.name = libmime.decodeWords(update.name);
+                } catch {
+                    // ignore
+                }
+            }
+
+            let response;
+            try {
+                response = await db.database.collection('addressregister').updateOne(
+                    {
+                        _id: addressId
+                    },
+                    {
+                        $set: update
+                    }
+                );
+            } catch (err) {
+                res.status(500);
+                return res.json({
+                    error: 'MongoDB Error: ' + err.message,
+                    code: 'InternalDatabaseError'
+                });
+            }
+
+            return res.json({
+                success: !!response.matchedCount
             });
         })
     );

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -170,14 +170,16 @@ class MessageHandler {
                 await this.database.collection('addressregister').findOneAndUpdate(
                     {
                         user,
-                        addrview: addr.addrview
+                        addrview: addr.addrview,
+                        disabled: false // if disabled then do not update
                     },
                     {
                         $set: updates,
                         $setOnInsert: {
                             user,
                             address: addr.address,
-                            addrview: addr.addrview
+                            addrview: addr.addrview,
+                            disabled: false
                         }
                     },
                     { upsert: true, projection: { _id: true } }


### PR DESCRIPTION
@andris9 
The current implementation of this PR will require a migration script.
I see two paths:
1. No migrations, be as backwards compatible as possible, instead of equality checks for `disabled` we add `$ne` operator. This will require no schema changes and will be compatible with older schemas, but is slower (considerably slower for a huge collection).
2. We implement either a separate migrations folder with .js migrations that can be ran via the command line or we implement a full migration manager that will check schema before starting WD server and run all necessary migrations (may take some time on bigger collections).