### PR TITLE
ZMS-25: Implement IMAP SORT

### DIFF
--- a/imap-core/lib/commands/sort.js
+++ b/imap-core/lib/commands/sort.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const imapHandler = require('../handler/imap-handler');
+const { parseQueryTerms } = require('./search');
+const { SORT_KEYS } = require('../sort-search-results');
+
+module.exports = {
+    state: 'Selected',
+    schema: false, // recursive search criteria
+
+    handler(command, callback) {
+        // Reuse SEARCH backend implementation
+        if (typeof this._server.onSearch !== 'function') {
+            return callback(null, {
+                response: 'NO',
+                message: command.command + ' not implemented'
+            });
+        }
+
+        const isUid = (command.command || '').toString().toUpperCase() === 'UID SORT';
+
+        let parsed;
+        try {
+            parsed = parseSortCommand(command.attributes, this.selected.uidList);
+        } catch (E) {
+            return callback(E);
+        }
+
+        if (!isSupportedCharset(parsed.charset)) {
+            return callback(null, {
+                response: 'NO',
+                code: 'BADCHARSET',
+                message: `Unsupported charset ${parsed.charset}`
+            });
+        }
+
+        const logdata = {
+            short_message: '[SORT]',
+            _mail_action: 'sort',
+            _user: this.session.user.id.toString(),
+            _mailbox: this.selected.mailbox,
+            _sess: this.id,
+            _charset: parsed.charset,
+            _sort: JSON.stringify(parsed.sort),
+            _query: JSON.stringify(parsed.query),
+            _terms: JSON.stringify(parsed.terms)
+        };
+
+        this._server.onSearch(
+            this.selected.mailbox,
+            {
+                query: parsed.query,
+                terms: parsed.terms,
+                isUid,
+                sort: parsed.sort,
+                charset: parsed.charset
+            },
+            this.session,
+            (err, results) => {
+                if (err) {
+                    logdata._error = err.message;
+                    logdata._code = err.code;
+                    logdata._response = err.response;
+                    this._server.loggelf(logdata);
+                    return callback(null, {
+                        response: 'NO',
+                        code: 'TEMPFAIL'
+                    });
+                }
+
+                let matches = results.uidList;
+                if (typeof matches === 'string') {
+                    return callback(null, {
+                        response: 'NO',
+                        code: matches.toUpperCase()
+                    });
+                }
+
+                let response = {
+                    tag: '*',
+                    command: 'SORT',
+                    attributes: []
+                };
+
+                if (Array.isArray(matches) && matches.length) {
+                    if (isUid) {
+                        response.attributes.push({
+                            type: 'TEXT',
+                            value: matches.join(' ')
+                        });
+                    } else {
+                        let uidList = this.selected.uidList || [];
+                        let uidIndex = new Map();
+                        let seqList = [];
+
+                        for (let i = 0; i < uidList.length; i++) {
+                            uidIndex.set(uidList[i], i + 1);
+                        }
+
+                        for (let i = 0; i < matches.length; i++) {
+                            let seq = uidIndex.get(matches[i]);
+                            if (seq) {
+                                seqList.push(seq);
+                            }
+                        }
+
+                        if (seqList.length) {
+                            response.attributes.push({
+                                type: 'TEXT',
+                                value: seqList.join(' ')
+                            });
+                        }
+                    }
+                }
+
+                this.send(imapHandler.compiler(response));
+
+                return callback(null, {
+                    response: 'OK',
+                    message: 'SORT completed'
+                });
+            }
+        );
+    },
+
+    parseSortCommand
+};
+
+function parseSortCommand(attributes, uidList) {
+    attributes = [].concat(attributes || []);
+
+    if (attributes.length < 3) {
+        throw new Error('Invalid arguments for SORT');
+    }
+
+    let sort = parseSortCriteria(attributes[0]);
+
+    let charset = ((attributes[1] && attributes[1].value) || '').toString().trim();
+    if (!charset) {
+        throw new Error('Invalid charset argument for SORT');
+    }
+
+    let terms = [];
+    flattenAttributeValues(attributes.slice(2), terms);
+    if (!terms.length) {
+        throw new Error('Missing search criteria for SORT');
+    }
+
+    let parsed = parseQueryTerms(terms, uidList);
+
+    return {
+        sort,
+        charset,
+        query: parsed.query,
+        terms: parsed.terms
+    };
+}
+
+function parseSortCriteria(criteria) {
+    let tokens = [];
+    flattenAttributeValues(criteria, tokens);
+    tokens = tokens.map(value => (value || '').toString().trim().toUpperCase()).filter(value => value);
+
+    if (!tokens.length) {
+        throw new Error('Invalid sort criteria for SORT');
+    }
+
+    let reverse = false;
+    let result = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+        let token = tokens[i];
+
+        if (token === 'REVERSE') {
+            if (reverse) {
+                throw new Error('Invalid sort criteria for SORT');
+            }
+            reverse = true;
+            continue;
+        }
+
+        let key = token.toLowerCase();
+        if (!SORT_KEYS.has(key)) {
+            throw new Error('Invalid sort criterion ' + token + ' for SORT');
+        }
+
+        result.push({
+            key,
+            reverse
+        });
+        reverse = false;
+    }
+
+    if (reverse || !result.length) {
+        throw new Error('Invalid sort criteria for SORT');
+    }
+
+    return result;
+}
+
+function flattenAttributeValues(elements, terms) {
+    elements = [].concat(elements || []);
+
+    elements.forEach(element => {
+        if (Array.isArray(element)) {
+            return flattenAttributeValues(element, terms);
+        }
+
+        if (element?.value) {
+            terms.push(element.value);
+            return;
+        }
+
+        terms.push(element);
+    });
+}
+
+function isSupportedCharset(charset) {
+    charset = (charset || '').toString().trim().toUpperCase();
+    return ['UTF-8', 'UTF8', 'US-ASCII', 'ASCII'].includes(charset);
+}

--- a/imap-core/lib/imap-command.js
+++ b/imap-core/lib/imap-command.js
@@ -45,6 +45,8 @@ const commands = new Map([
     ['UID FETCH', require('./commands/fetch')],
     ['SEARCH', require('./commands/search')],
     ['UID SEARCH', require('./commands/search')],
+    ['SORT', require('./commands/sort')],
+    ['UID SORT', require('./commands/sort')],
     ['ENABLE', require('./commands/enable')],
     ['GETQUOTAROOT', require('./commands/getquotaroot')],
     ['SETQUOTA', require('./commands/setquota')],

--- a/imap-core/lib/imap-tools.js
+++ b/imap-core/lib/imap-tools.js
@@ -790,6 +790,7 @@ module.exports.sendCapabilityResponse = connection => {
         capabilities.push('UIDPLUS');
         capabilities.push('CONDSTORE');
         capabilities.push('UTF8=ACCEPT');
+        capabilities.push('SORT');
 
         capabilities.push('MOVE');
 
@@ -810,6 +811,7 @@ module.exports.sendCapabilityResponse = connection => {
         capabilities.push('ENABLE');
         capabilities.push('CONDSTORE');
         capabilities.push('UTF8=ACCEPT');
+        capabilities.push('SORT');
 
         capabilities.push('MOVE');
 

--- a/imap-core/lib/sort-search-results.js
+++ b/imap-core/lib/sort-search-results.js
@@ -1,0 +1,301 @@
+'use strict';
+
+const addressparser = require('nodemailer/lib/addressparser');
+const libmime = require('libmime');
+
+const SORT_KEYS = new Set(['arrival', 'cc', 'date', 'from', 'size', 'subject', 'to']);
+
+module.exports.SORT_KEYS = SORT_KEYS;
+module.exports.sortSearchResults = sortSearchResults;
+
+function sortSearchResults(messages, sortCriteria, options) {
+    messages = [].concat(messages || []);
+    sortCriteria = []
+        .concat(sortCriteria || [])
+        .map(entry => ({
+            key: (entry?.key || '').toString().toLowerCase().trim(),
+            reverse: !!entry?.reverse
+        }))
+        .filter(entry => SORT_KEYS.has(entry.key));
+
+    if (!messages.length || !sortCriteria.length) {
+        return messages;
+    }
+
+    options = options || {};
+    const uidList = [].concat(options.uidList || []);
+    const uidIndex = new Map();
+    for (let i = 0; i < uidList.length; i++) {
+        uidIndex.set(uidList[i], i + 1);
+    }
+
+    const collator = options.collator || new Intl.Collator(undefined, { sensitivity: 'base', usage: 'sort' }); // i;unicode-casemap collation
+
+    const decorated = messages.map((message, index) => {
+        const values = {};
+        for (let i = 0; i < sortCriteria.length; i++) {
+            values[sortCriteria[i].key] = getSortValue(message, sortCriteria[i].key);
+        }
+
+        let seq = Number(message?.seq) || 0;
+        if (!seq) {
+            seq = uidIndex.get(message?.uid) || index + 1;
+        }
+
+        return {
+            message,
+            seq,
+            values
+        };
+    });
+
+    decorated.sort((a, b) => {
+        for (let i = 0; i < sortCriteria.length; i++) {
+            const criterion = sortCriteria[i];
+            const key = criterion.key;
+            const aValue = a.values[key];
+            const bValue = b.values[key];
+
+            let cmp = 0;
+            if (key === 'arrival' || key === 'date' || key === 'size') {
+                cmp = compareNumbers(aValue, bValue);
+            } else {
+                cmp = collator.compare(aValue || '', bValue || '');
+            }
+
+            if (cmp) {
+                return criterion.reverse ? -cmp : cmp;
+            }
+        }
+
+        // RFC 5256 tie-breaker: mailbox order (sequence number)
+        return a.seq - b.seq;
+    });
+
+    return decorated.map(entry => entry.message);
+}
+
+function compareNumbers(a, b) {
+    a = Number(a) || 0;
+    b = Number(b) || 0;
+
+    if (a === b) {
+        return 0;
+    }
+
+    return a < b ? -1 : 1;
+}
+
+function getSortValue(message, key) {
+    switch (key) {
+        case 'arrival':
+            return getTimestamp(message?.idate);
+
+        case 'date':
+            return getTimestamp(resolveSentDate(message));
+
+        case 'size':
+            return Number(message?.size) || 0;
+
+        case 'subject':
+            return normalizeBaseSubject(resolveSubject(message));
+
+        case 'from':
+        case 'to':
+        case 'cc':
+            return resolveFirstMailbox(message, key);
+    }
+
+    return '';
+}
+
+function getTimestamp(value) {
+    if (!value) {
+        return false;
+    }
+
+    if ('getTime' in value) {
+        value = value.getTime();
+    }
+
+    if (typeof value === 'string') {
+        value = new Date(value).getTime();
+    }
+
+    if (!Number.isFinite(value)) {
+        return false;
+    }
+
+    return value || false;
+}
+
+function resolveSentDate(message) {
+    let headerDate = message?.hdate;
+    if (!headerDate && message?.mimeTree?.parsedHeader) {
+        headerDate = [].concat(message.mimeTree.parsedHeader.date || []).pop() || false;
+    }
+
+    return headerDate || message?.idate || false;
+}
+
+function resolveSubject(message) {
+    let subject = (message && message.subject) || '';
+
+    if (!subject) {
+        subject = getIndexedHeaderValue(message, 'subject');
+    }
+
+    if (!subject && message && message.mimeTree && message.mimeTree.parsedHeader) {
+        subject = [].concat(message.mimeTree.parsedHeader.subject || []).pop() || '';
+    }
+
+    subject = (subject || '').toString();
+    try {
+        subject = libmime.decodeWords(subject);
+    } catch (E) {
+        // ignore decode errors
+    }
+
+    return subject;
+}
+
+function normalizeBaseSubject(subject) {
+    subject = (subject || '')
+        .toString()
+        .replace(/\r?\n|\t/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    // Keep behavior aligned with existing WildDuck subject normalization
+    let match = true;
+    while (match) {
+        match = false;
+
+        // RFC 5256 step 6 style wrapper: [fwd: ...]
+        // Unwrap and re-run normalization from the start.
+        let fwdWrapper = subject.match(/^\[fwd:\s*(.*?)\s*\]$/i);
+        if (fwdWrapper) {
+            subject = (fwdWrapper[1] || '').trim();
+            match = true;
+            continue;
+        }
+
+        subject = subject
+            .replace(/^(re|fwd?)\s*:|^\[.+?\](?=\s.+)|\s*\(fwd\)\s*$/gi, () => {
+                match = true;
+                return '';
+            })
+            .trim();
+    }
+
+    return subject;
+}
+
+function resolveFirstMailbox(message, key) {
+    // Prefer parsed address objects from mime tree (imap-core test server messages)
+    let parsed = resolveParsedHeaderAddresses(message, key);
+    if (parsed.length) {
+        return parsed[0];
+    }
+
+    // Fall back to indexed header value (WildDuck DB messages)
+    parsed = parseAddressList(getIndexedHeaderValue(message, key));
+    if (parsed.length) {
+        return parsed[0];
+    }
+
+    // Fall back to ENVELOPE if available
+    const envelopePos = {
+        from: 2,
+        to: 5,
+        cc: 6
+    }[key];
+
+    const envelopeAddresses = message && Array.isArray(message.envelope) && Array.isArray(message.envelope[envelopePos]) ? message.envelope[envelopePos] : [];
+    if (envelopeAddresses.length && Array.isArray(envelopeAddresses[0])) {
+        const first = envelopeAddresses[0];
+        const user = (first[2] || '').toString().trim();
+        const domain = (first[3] || '').toString().trim();
+        return normalizeMailboxAddress(user && domain ? `${user}@${domain}` : user);
+    }
+
+    return '';
+}
+
+function resolveParsedHeaderAddresses(message, key) {
+    const value =
+        message && message.mimeTree && message.mimeTree.parsedHeader && Object.prototype.hasOwnProperty.call(message.mimeTree.parsedHeader, key)
+            ? message.mimeTree.parsedHeader[key]
+            : false;
+
+    if (!value) {
+        return [];
+    }
+
+    if (Array.isArray(value) && value.length && value[0] && typeof value[0] === 'object' && value[0].address) {
+        return value.map(entry => normalizeMailboxAddress(entry && entry.address)).filter(Boolean);
+    }
+
+    return parseAddressList(value);
+}
+
+function parseAddressList(value) {
+    if (!value) {
+        return [];
+    }
+
+    let input = value;
+    if (Array.isArray(input)) {
+        input = input.map(entry => (entry || '').toString()).join(', ');
+    }
+
+    try {
+        return addressparser((input || '').toString())
+            .map(entry => normalizeMailboxAddress(entry && entry.address))
+            .filter(Boolean);
+    } catch (E) {
+        return [];
+    }
+}
+
+function getIndexedHeaderValue(message, key) {
+    const headers = (message && message.headers) || [];
+
+    for (let i = 0; i < headers.length; i++) {
+        const entry = headers[i];
+        if (!entry) {
+            continue;
+        }
+
+        if (entry?.key && entry?.value && entry.key.toString().toLowerCase() === key) {
+            return entry.value.toString();
+        }
+
+        if (typeof entry === 'string') {
+            const splitPos = entry.indexOf(':');
+            if (splitPos < 0) {
+                continue;
+            }
+
+            const headerKey = entry.substring(0, splitPos).trim().toLowerCase();
+            if (headerKey === key) {
+                return entry.substring(splitPos + 1).trim();
+            }
+        }
+    }
+
+    return '';
+}
+
+function normalizeMailboxAddress(address) {
+    address = (address || '').toString().trim();
+    if (!address) {
+        return '';
+    }
+
+    if (address.charAt(0) === '<' && address.charAt(address.length - 1) === '>') {
+        address = address.substring(1, address.length - 1);
+    }
+
+    return address.toLowerCase();
+}

--- a/imap-core/test/protocol-test.js
+++ b/imap-core/test/protocol-test.js
@@ -2001,4 +2001,60 @@ describe('IMAP Protocol integration tests', function () {
             );
         });
     });
+
+    describe('SORT command', function () {
+        it('should sort by FROM', function (done) {
+            let cmds = ['T1 LOGIN testuser pass', 'T2 SELECT INBOX', 'T3 SORT (FROM) UTF-8 ALL', 'T4 LOGOUT'];
+
+            testClient(
+                {
+                    commands: cmds,
+                    secure: true,
+                    port
+                },
+                function (resp) {
+                    resp = resp.toString();
+                    expect(/^\* SORT 3 2 1 4 5 6$/m.test(resp)).to.be.true;
+                    expect(/^T3 OK/m.test(resp)).to.be.true;
+                    done();
+                }
+            );
+        });
+
+        it('should support UID SORT', function (done) {
+            let cmds = ['T1 LOGIN testuser pass', 'T2 SELECT INBOX', 'T3 UID SORT (FROM) UTF-8 ALL', 'T4 LOGOUT'];
+
+            testClient(
+                {
+                    commands: cmds,
+                    secure: true,
+                    port
+                },
+                function (resp) {
+                    resp = resp.toString();
+                    expect(/^\* SORT 103 102 101 104 105 106$/m.test(resp)).to.be.true;
+                    expect(/^T3 OK/m.test(resp)).to.be.true;
+                    done();
+                }
+            );
+        });
+
+        it('should reject unsupported charset', function (done) {
+            let cmds = ['T1 LOGIN testuser pass', 'T2 SELECT INBOX', 'T3 SORT (FROM) ISO-8859-1 ALL', 'T4 LOGOUT'];
+
+            testClient(
+                {
+                    commands: cmds,
+                    secure: true,
+                    port
+                },
+                function (resp) {
+                    resp = resp.toString();
+                    expect(/^\* SORT/m.test(resp)).to.be.false;
+                    expect(/^T3 NO \[BADCHARSET\]/m.test(resp)).to.be.true;
+                    done();
+                }
+            );
+        });
+    });
 });

--- a/imap-core/test/sort-test.js
+++ b/imap-core/test/sort-test.js
@@ -1,0 +1,94 @@
+/* eslint-disable no-invalid-this */
+/*eslint no-unused-expressions: 0, prefer-arrow-callback: 0 */
+
+'use strict';
+
+const { parseSortCommand } = require('../lib/commands/sort');
+const { sortSearchResults } = require('../lib/sort-search-results');
+
+const chai = require('chai');
+const expect = chai.expect;
+chai.config.includeStack = true;
+
+describe('#parseSortCommand', function () {
+    const uidList = [45, 49, 50, 52, 53, 60];
+
+    it('should parse SORT arguments', function () {
+        const parsed = parseSortCommand(
+            [
+                [{ type: 'ATOM', value: 'SUBJECT' }, { type: 'ATOM', value: 'REVERSE' }, { type: 'ATOM', value: 'DATE' }],
+                { type: 'ATOM', value: 'UTF-8' },
+                { type: 'ATOM', value: 'ALL' }
+            ],
+            uidList
+        );
+
+        expect(parsed.sort).to.deep.equal([
+            { key: 'subject', reverse: false },
+            { key: 'date', reverse: true }
+        ]);
+        expect(parsed.charset).to.equal('UTF-8');
+        expect(parsed.query).to.deep.equal([
+            {
+                key: 'all',
+                value: true
+            }
+        ]);
+    });
+
+    it('should fail on invalid sort criteria', function () {
+        const fn = parseSortCommand.bind(null, [[{ type: 'ATOM', value: 'THREADID' }], { type: 'ATOM', value: 'UTF-8' }, { type: 'ATOM', value: 'ALL' }], uidList);
+        expect(fn).to.throw(/Invalid sort criterion/i);
+    });
+
+    it('should fail when search criteria is missing', function () {
+        const fn = parseSortCommand.bind(null, [[{ type: 'ATOM', value: 'FROM' }], { type: 'ATOM', value: 'UTF-8' }], uidList);
+        expect(fn).to.throw(/Invalid arguments for SORT|Missing search criteria for SORT/i);
+    });
+});
+
+describe('#sortSearchResults', function () {
+    it('should sort by FROM with empty values first', function () {
+        const messages = [
+            { uid: 10, seq: 1, headers: [{ key: 'from', value: 'z@example.com' }] },
+            { uid: 20, seq: 2, headers: [{ key: 'from', value: 'a@example.com' }] },
+            { uid: 30, seq: 3, headers: [] }
+        ];
+
+        const sorted = sortSearchResults(messages, [{ key: 'from', reverse: false }]).map(message => message.uid);
+        expect(sorted).to.deep.equal([30, 20, 10]);
+    });
+
+    it('should keep sequence order for equal values even with REVERSE', function () {
+        const messages = [
+            { uid: 10, seq: 1, headers: [{ key: 'from', value: 'same@example.com' }] },
+            { uid: 20, seq: 2, headers: [{ key: 'from', value: 'same@example.com' }] },
+            { uid: 30, seq: 3, headers: [{ key: 'from', value: 'same@example.com' }] }
+        ];
+
+        const sorted = sortSearchResults(messages, [{ key: 'from', reverse: true }]).map(message => message.uid);
+        expect(sorted).to.deep.equal([10, 20, 30]);
+    });
+
+    it('should normalize subject prefixes for SUBJECT sort', function () {
+        const messages = [
+            { uid: 10, seq: 1, subject: 'Re: hello' },
+            { uid: 20, seq: 2, subject: 'hello' },
+            { uid: 30, seq: 3, subject: '[ext] Fwd: hello' }
+        ];
+
+        const sorted = sortSearchResults(messages, [{ key: 'subject', reverse: false }]).map(message => message.uid);
+        expect(sorted).to.deep.equal([10, 20, 30]);
+    });
+
+    it('should unwrap [fwd: ...] wrapper for SUBJECT sort', function () {
+        const messages = [
+            { uid: 10, seq: 1, subject: '[fwd: Re: hello]' },
+            { uid: 20, seq: 2, subject: 'hello' },
+            { uid: 30, seq: 3, subject: '[fwd: [ext] Fwd: hello]' }
+        ];
+
+        const sorted = sortSearchResults(messages, [{ key: 'subject', reverse: false }]).map(message => message.uid);
+        expect(sorted).to.deep.equal([10, 20, 30]);
+    });
+});

--- a/imap-core/test/test-server.js
+++ b/imap-core/test/test-server.js
@@ -6,6 +6,7 @@ const MemoryNotifier = require('./memory-notifier.js');
 const fs = require('fs');
 const parseMimeTree = require('../lib/indexer/parse-mime-tree');
 const imapHandler = require('../lib/handler/imap-handler');
+const { sortSearchResults } = require('../lib/sort-search-results');
 
 module.exports = function (options) {
     // This example uses global folders and subscriptions
@@ -592,11 +593,19 @@ module.exports = function (options) {
 
         let folder = folders.get(mailbox);
         let highestModseq = 0;
+        let useSorting = Array.isArray(options.sort) && options.sort.length;
 
         let uidList = [];
+        let matchedMessages = [];
         let checked = 0;
         let checkNext = () => {
             if (checked >= folder.messages.length) {
+                if (useSorting) {
+                    uidList = sortSearchResults(matchedMessages, options.sort, {
+                        uidList: session.selected && session.selected.uidList
+                    }).map(message => message.uid);
+                }
+
                 return callback(null, {
                     uidList,
                     highestModseq
@@ -611,7 +620,11 @@ module.exports = function (options) {
                     highestModseq = message.modseq;
                 }
                 if (match) {
-                    uidList.push(message.uid);
+                    if (useSorting) {
+                        matchedMessages.push(message);
+                    } else {
+                        uidList.push(message.uid);
+                    }
                 }
                 checkNext();
             });

--- a/lib/handlers/on-search.js
+++ b/lib/handlers/on-search.js
@@ -3,6 +3,13 @@
 const db = require('../db');
 const tools = require('../tools');
 const consts = require('../consts');
+const { sortSearchResults } = require('../../imap-core/lib/sort-search-results');
+
+const MONGO_SORT_FIELDS = new Map([
+    ['arrival', 'idate'],
+    ['date', 'hdate'],
+    ['size', 'size']
+]);
 
 /**
  * Returns an array of matching UID values
@@ -337,18 +344,25 @@ module.exports = server => (mailbox, options, session, callback) => {
                 JSON.stringify(query)
             );
 
+            let useSorting = Array.isArray(options.sort) && options.sort.length;
+            let mongoSort = useSorting ? buildMongoSort(options.sort) : false;
+            let useMongoSortingOnly = !!mongoSort?.fullyCovered;
+            let projection = useSorting && !useMongoSortingOnly ? buildSortProjection(options.sort) : { uid: true, modseq: true };
+
             let cursor = db.database
                 .collection('messages')
                 .find(query)
-                .project({
-                    uid: true,
-                    modseq: true
-                })
+                .project(projection)
                 .withReadPreference('secondaryPreferred')
                 .maxTimeMS(consts.DB_MAX_TIME_MESSAGES);
 
+            if (useMongoSortingOnly) {
+                cursor = cursor.sort(mongoSort.sort);
+            }
+
             let highestModseq = 0;
             let uidList = [];
+            let matchedMessages = [];
 
             let processNext = () => {
                 cursor.next((err, message) => {
@@ -379,6 +393,12 @@ module.exports = server => (mailbox, options, session, callback) => {
                         return callback(new Error('Can not make requested search query'));
                     }
                     if (!message) {
+                        if (useSorting && !useMongoSortingOnly) {
+                            uidList = sortSearchResults(matchedMessages, options.sort, {
+                                uidList: session.selected && session.selected.uidList
+                            }).map(entry => entry.uid);
+                        }
+
                         return cursor.close(() =>
                             callback(null, {
                                 uidList,
@@ -391,7 +411,11 @@ module.exports = server => (mailbox, options, session, callback) => {
                         highestModseq = message.modseq;
                     }
 
-                    uidList.push(message.uid);
+                    if (useSorting && !useMongoSortingOnly) {
+                        matchedMessages.push(message);
+                    } else {
+                        uidList.push(message.uid);
+                    }
                     setImmediate(processNext);
                 });
             };
@@ -400,3 +424,74 @@ module.exports = server => (mailbox, options, session, callback) => {
         }
     );
 };
+
+function buildMongoSort(sortCriteria) {
+    let sort = [];
+    let fullyCovered = true;
+    let seen = new Set();
+
+    [].concat(sortCriteria || []).forEach(sortEntry => {
+        let key = ((sortEntry && sortEntry.key) || '').toString().toLowerCase().trim();
+        let field = MONGO_SORT_FIELDS.get(key);
+        if (!field) {
+            fullyCovered = false;
+            return;
+        }
+
+        if (seen.has(field)) {
+            return;
+        }
+
+        seen.add(field);
+        sort.push([field, sortEntry && sortEntry.reverse ? -1 : 1]);
+    });
+
+    if (!sort.length) {
+        return false;
+    }
+
+    if (!seen.has('uid')) {
+        // RFC 5256 tie-breaker uses sequence order; for selected mailbox, uid order matches mailbox order.
+        sort.push(['uid', 1]);
+    }
+
+    return { sort, fullyCovered };
+}
+
+function buildSortProjection(sortCriteria) {
+    let projection = {
+        uid: true,
+        modseq: true
+    };
+
+    [].concat(sortCriteria || []).forEach(sort => {
+        let key = ((sort && sort.key) || '').toString().toLowerCase().trim();
+        switch (key) {
+            case 'arrival':
+                projection.idate = true;
+                break;
+
+            case 'date':
+                // DATE primarily uses hdate and falls back to idate
+                projection.hdate = true;
+                projection.idate = true;
+                break;
+
+            case 'size':
+                projection.size = true;
+                break;
+
+            case 'subject':
+                projection.subject = true;
+                break;
+
+            case 'from':
+            case 'to':
+            case 'cc':
+                projection.headers = true;
+                break;
+        }
+    });
+
+    return projection;
+}


### PR DESCRIPTION
Add support and implement IMAP SORT command per RFC 5256 (https://datatracker.ietf.org/doc/html/rfc5256).
In case sorting is based on subject, from, to, cc the sorting happens on WD side, otherwise mongodb is used for sorting.