### PR TITLE
Support for custom keywords

### DIFF
--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -6,7 +6,7 @@
         "contact": {
             "url": "https://github.com/zone-eu/wildduck"
         },
-        "version": "1.47.1"
+        "version": "1.48.1"
     },
     "servers": [
         {
@@ -390,6 +390,31 @@
                                         "type": "string",
                                         "description": "Public PGP key for the User that is used for encryption. Use empty string to remove the key"
                                     },
+                                    "smimeCerts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "S/MIME recipient certificates (PEM). Messages are encrypted for all listed certificates. Mutually exclusive with PGP (pubKey)."
+                                    },
+                                    "smimeCipher": {
+                                        "type": "string",
+                                        "description": "S/MIME content encryption cipher.",
+                                        "enum": [
+                                            "AES-CBC",
+                                            "AES-GCM"
+                                        ],
+                                        "default": "AES-CBC"
+                                    },
+                                    "smimeKeyTransport": {
+                                        "type": "string",
+                                        "description": "S/MIME RSA key transport algorithm.",
+                                        "enum": [
+                                            "PKCS#1 v1.5",
+                                            "OAEP"
+                                        ],
+                                        "default": "PKCS#1 v1.5"
+                                    },
                                     "encryptMessages": {
                                         "type": "boolean",
                                         "description": "If true then received messages are encrypted",
@@ -556,7 +581,7 @@
                                 "properties": {
                                     "existingPassword": {
                                         "type": "string",
-                                        "description": "If provided then validates against account password before applying any changes"
+                                        "description": "Validates against account password before applying any changes."
                                     },
                                     "password": {
                                         "type": "string",
@@ -624,6 +649,29 @@
                                     "pubKey": {
                                         "type": "string",
                                         "description": "Public PGP key for the User that is used for encryption. Use empty string to remove the key"
+                                    },
+                                    "smimeCerts": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "S/MIME recipient certificates (PEM). Messages are encrypted for all listed certificates. Mutually exclusive with PGP (pubKey). Use empty array to remove."
+                                    },
+                                    "smimeCipher": {
+                                        "type": "string",
+                                        "description": "S/MIME content encryption cipher",
+                                        "enum": [
+                                            "AES-CBC",
+                                            "AES-GCM"
+                                        ]
+                                    },
+                                    "smimeKeyTransport": {
+                                        "type": "string",
+                                        "description": "S/MIME RSA key transport algorithm",
+                                        "enum": [
+                                            "PKCS#1 v1.5",
+                                            "OAEP"
+                                        ]
                                     },
                                     "encryptMessages": {
                                         "type": "boolean",
@@ -2892,6 +2940,27 @@
                                         "description": "Optional metadata, must be an object or JSON formatted string",
                                         "format": "any"
                                     },
+                                    "keywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to set on the message. Replaces all existing custom keywords. System flags are not affected."
+                                    },
+                                    "addKeywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to add to the message without affecting existing keywords."
+                                    },
+                                    "removeKeywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to remove from the message without affecting other keywords."
+                                    },
                                     "sess": {
                                         "type": "string",
                                         "description": "Session identifier for the logs"
@@ -3051,6 +3120,13 @@
                                         "type": "boolean",
                                         "description": "Is the message a draft or not",
                                         "default": false
+                                    },
+                                    "keywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to set on the uploaded message"
                                     },
                                     "raw": {
                                         "type": "string",
@@ -3365,6 +3441,25 @@
                         }
                     },
                     {
+                        "name": "keyword",
+                        "in": "query",
+                        "description": "If set, then matches only messages that have this custom keyword set",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "useAndSearch",
+                        "in": "query",
+                        "description": "If true, then fulltext search terms are combined with AND semantics",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
                         "name": "includeHeaders",
                         "in": "query",
                         "description": "Comma separated list of header keys to include in the response",
@@ -3583,6 +3678,15 @@
                                         "type": "boolean",
                                         "description": "If true, then matches only messages with \\Seen flags"
                                     },
+                                    "keyword": {
+                                        "type": "string",
+                                        "description": "If set, then matches only messages that have this custom keyword set"
+                                    },
+                                    "useAndSearch": {
+                                        "type": "boolean",
+                                        "description": "If true, then fulltext search terms are combined with AND semantics",
+                                        "default": false
+                                    },
                                     "includeHeaders": {
                                         "type": "string",
                                         "description": "Comma separated list of header keys to include in the response",
@@ -3625,6 +3729,27 @@
                                                 "type": "boolean",
                                                 "description": "If true then delete all found messages",
                                                 "default": false
+                                            },
+                                            "keywords": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Custom keywords to set on matched messages. Replaces all existing custom keywords."
+                                            },
+                                            "addKeywords": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Custom keywords to add to matched messages without affecting existing keywords."
+                                            },
+                                            "removeKeywords": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Custom keywords to remove from matched messages without affecting other keywords."
                                             }
                                         }
                                     }
@@ -3800,6 +3925,27 @@
                                         "type": "object",
                                         "description": "Optional metadata, must be an object or JSON formatted string",
                                         "format": "any"
+                                    },
+                                    "keywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to set on the message, overrides any existing keywords"
+                                    },
+                                    "addKeywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to add to the message without affecting existing keywords, can not be used together with `keywords`"
+                                    },
+                                    "removeKeywords": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "Custom keywords to remove from the message without affecting other keywords, can not be used together with `keywords`"
                                     },
                                     "sess": {
                                         "type": "string",
@@ -9157,6 +9303,28 @@
                     "fingerprint"
                 ]
             },
+            "SmimeCertInfoItem": {
+                "type": "object",
+                "properties": {
+                    "subject": {
+                        "type": "string",
+                        "description": "Certificate subject CN"
+                    },
+                    "serial": {
+                        "type": "string",
+                        "description": "Certificate serial number"
+                    },
+                    "fingerprint": {
+                        "type": "string",
+                        "description": "SHA-256 fingerprint of the certificate"
+                    }
+                },
+                "required": [
+                    "subject",
+                    "serial",
+                    "fingerprint"
+                ]
+            },
             "Recipients": {
                 "type": "object",
                 "description": "Sending quota",
@@ -9436,6 +9604,36 @@
                     },
                     "keyInfo": {
                         "$ref": "#/components/schemas/KeyInfo"
+                    },
+                    "smimeCerts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "S/MIME recipient certificates (PEM)"
+                    },
+                    "smimeCipher": {
+                        "type": "string",
+                        "description": "S/MIME content encryption cipher",
+                        "enum": [
+                            "AES-CBC",
+                            "AES-GCM"
+                        ]
+                    },
+                    "smimeKeyTransport": {
+                        "type": "string",
+                        "description": "S/MIME RSA key transport algorithm",
+                        "enum": [
+                            "PKCS#1 v1.5",
+                            "OAEP"
+                        ]
+                    },
+                    "smimeCertInfo": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SmimeCertInfoItem"
+                        },
+                        "description": "Information about S/MIME certificates or empty array if not available"
                     },
                     "metaData": {
                         "type": "object",
@@ -10789,6 +10987,13 @@
                         "type": "boolean",
                         "description": "Does this message have a $Forwarded flag"
                     },
+                    "keywords": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Custom keywords set on this message"
+                    },
                     "references": {
                         "type": "array",
                         "items": {
@@ -11746,6 +11951,13 @@
                             }
                         ],
                         "description": "Custom metadata object set for this message"
+                    },
+                    "keywords": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Custom keywords set on this message"
                     },
                     "references": {
                         "type": "array",

--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -2732,6 +2732,66 @@
                 }
             }
         },
+        "/users/{user}/keyword-counters/{keyword}": {
+            "get": {
+                "tags": [
+                    "Messages"
+                ],
+                "summary": "Get keyword counter",
+                "description": "Returns total and unseen counters for a custom keyword",
+                "operationId": "getKeywordCounters",
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID of the User",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "keyword",
+                        "in": "path",
+                        "description": "Keyword to count",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sess",
+                        "in": "query",
+                        "description": "Session identifier for the logs",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ip",
+                        "in": "query",
+                        "description": "IP address for the logs ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/KeywordCounterResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/users/{user}/mailboxes/{mailbox}/messages": {
             "get": {
                 "tags": [
@@ -10795,6 +10855,32 @@
                     "subscribed",
                     "hidden",
                     "encryptMessages",
+                    "total",
+                    "unseen"
+                ]
+            },
+            "KeywordCounterResponse": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "keyword": {
+                        "type": "string",
+                        "description": "Keyword name"
+                    },
+                    "total": {
+                        "type": "number",
+                        "description": "Total number of messages with this keyword"
+                    },
+                    "unseen": {
+                        "type": "number",
+                        "description": "Unseen number of messages with this keyword"
+                    }
+                },
+                "required": [
+                    "success",
+                    "keyword",
                     "total",
                     "unseen"
                 ]

--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -12488,6 +12488,13 @@
                             "type": "string"
                         },
                         "description": "An array of forwarding targets. The value could either be an email address or a relay url to next MX server (\"smtp://mx2.zone.eu:25\") or an URL where mail contents are POSTed to"
+                    },
+                    "keywords": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "An array of keywords to apply to matching messages"
                     }
                 }
             },

--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -2792,6 +2792,57 @@
                 }
             }
         },
+        "/users/{user}/flagged-counter": {
+            "get": {
+                "tags": [
+                    "Messages"
+                ],
+                "summary": "Get flagged counter",
+                "description": "Returns total and unseen counters for flagged messages",
+                "operationId": "getFlaggedCounter",
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID of the User",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sess",
+                        "in": "query",
+                        "description": "Session identifier for the logs",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ip",
+                        "in": "query",
+                        "description": "IP address for the logs ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/FlaggedCounterResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/users/{user}/mailboxes/{mailbox}/messages": {
             "get": {
                 "tags": [
@@ -10881,6 +10932,27 @@
                 "required": [
                     "success",
                     "keyword",
+                    "total",
+                    "unseen"
+                ]
+            },
+            "FlaggedCounterResponse": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "total": {
+                        "type": "number",
+                        "description": "Total number of flagged messages"
+                    },
+                    "unseen": {
+                        "type": "number",
+                        "description": "Unseen number of flagged messages"
+                    }
+                },
+                "required": [
+                    "success",
                     "total",
                     "unseen"
                 ]

--- a/lib/api/filters.js
+++ b/lib/api/filters.js
@@ -875,6 +875,10 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                 filterData.action.targets = targets;
             }
 
+            if (Array.isArray(values.action.keywords) && values.action.keywords.length) {
+                filterData.action.keywords = values.action.keywords;
+            }
+
             if (values.action.mailbox) {
                 let mailboxData;
                 try {
@@ -1165,6 +1169,14 @@ module.exports = (db, server, userHandler, settingsHandler) => {
                     hasChanges = true;
                 }
 
+                if (Array.isArray(values.action.keywords) && values.action.keywords.length) {
+                    $set['action.keywords'] = values.action.keywords;
+                    hasChanges = true;
+                } else if ('keywords' in req.params.action) {
+                    $unset['action.keywords'] = true;
+                    hasChanges = true;
+                }
+
                 if (values.action) {
                     if (!values.action.mailbox) {
                         if ('mailbox' in req.params.action) {
@@ -1361,6 +1373,11 @@ function getFilterStrings(filter, mailboxes, options) {
                                 })
                                 .join(', ')
                         ];
+                    }
+                    break;
+                case 'keywords':
+                    if (filter.action[key] && filter.action[key].length) {
+                        return ['apply keywords', filter.action[key].join(', ')];
                     }
                     break;
             }

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -16,7 +16,7 @@ const forward = require('../forward');
 const Maildropper = require('../maildropper');
 const util = require('util');
 const roles = require('../roles');
-const { nextPageCursorSchema, previousPageCursorSchema, sessSchema, sessIPSchema, booleanSchema, metaDataSchema } = require('../schemas');
+const { nextPageCursorSchema, previousPageCursorSchema, sessSchema, sessIPSchema, booleanSchema, metaDataSchema, keywordsSchema } = require('../schemas');
 const { preprocessAttachments } = require('../data-url');
 const TaskHandler = require('../task-handler');
 const { prepareSearchFilter, uidRangeStringToQuery } = require('../prepare-search-filter');
@@ -39,12 +39,6 @@ const { userId, mailboxId, messageId } = require('../schemas/request/general-sch
 const { MsgEnvelope, MsgVerificationResults } = require('../schemas/response/messages-schemas');
 const { successRes } = require('../schemas/response/general-schemas');
 const { mongopagingFindWrapper } = require('../mongopaging-find-wrapper');
-
-const keywordsSchema = Joi.array().items(
-    Joi.string()
-        .max(255)
-        .regex(/^[^\s"%()*[\\\]{]+$/)
-);
 
 module.exports = (db, server, messageHandler, userHandler, storageHandler, settingsHandler) => {
     let maildrop = new Maildropper({

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -40,6 +40,12 @@ const { MsgEnvelope, MsgVerificationResults } = require('../schemas/response/mes
 const { successRes } = require('../schemas/response/general-schemas');
 const { mongopagingFindWrapper } = require('../mongopaging-find-wrapper');
 
+const keywordsSchema = Joi.array().items(
+    Joi.string()
+        .max(255)
+        .regex(/^[^\s\\(){%*"[\]]+$/)
+);
+
 module.exports = (db, server, messageHandler, userHandler, storageHandler, settingsHandler) => {
     let maildrop = new Maildropper({
         db,
@@ -140,7 +146,9 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             ...requestBody,
             ...queryParams,
             ...pathParams
-        });
+        })
+            .oxor('keywords', 'addKeywords')
+            .oxor('keywords', 'removeKeywords');
 
         const result = schema.validate(req.params, {
             abortEarly: false,
@@ -229,19 +237,16 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     moveTo,
                     lock.id
                 );
-                extendLockIntervalTimer = setInterval(
-                    () => {
-                        server.lock
-                            .extendLock(lock, LOCK_TTL)
-                            .then(info => {
-                                log.verbose('API', `Lock extended lock=${info.id} result=${info.success ? 'yes' : 'no'}`);
-                            })
-                            .catch(err => {
-                                log.verbose('API', 'Failed to extend lock lock=%s error=%s', lock?.id, err.message);
-                            });
-                    },
-                    Math.round(LOCK_TTL * 0.8)
-                );
+                extendLockIntervalTimer = setInterval(() => {
+                    server.lock
+                        .extendLock(lock, LOCK_TTL)
+                        .then(info => {
+                            log.verbose('API', `Lock extended lock=${info.id} result=${info.success ? 'yes' : 'no'}`);
+                        })
+                        .catch(err => {
+                            log.verbose('API', 'Failed to extend lock lock=%s error=%s', lock?.id, err.message);
+                        });
+                }, Math.round(LOCK_TTL * 0.8));
             } catch (err) {
                 res.status(500);
                 return res.json({
@@ -409,6 +414,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                         draft: booleanSchema.required().description('is this message a draft'),
                                         answered: booleanSchema.required().description('Does this message have a Answered flag'),
                                         forwarded: booleanSchema.required().description('Does this message have a $Forwarded flag'),
+                                        keywords: Joi.array().items(Joi.string()).description('Custom keywords set on this message'),
                                         references: Joi.array().items(Joi.string()).required().description('References'),
                                         bimi: Joi.object({
                                             certified: booleanSchema.description('If true, then this logo is from a VMC file'),
@@ -656,6 +662,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
         flagged: booleanSchema.description('If true, then matches only messages with \\Flagged flags'),
         unseen: booleanSchema.description('If true, then matches only messages without \\Seen flags. Takes precedence over the seen flag'),
         seen: booleanSchema.description('If true, then matches only messages with \\Seen flags'),
+        keyword: Joi.string().max(255).trim().empty('').description('If set, then matches only messages that have this custom keyword set'),
         useAndSearch: booleanSchema.default(false).description('If true, then fulltext search terms are combined with AND semantics'),
         includeHeaders: Joi.string()
             .max(1024)
@@ -765,6 +772,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                         flagged: booleanSchema.required().description('Does this message have a \\Flagged flag'),
                                         answered: booleanSchema.required().description('Does this message have a \\Answered flag'),
                                         forwarded: booleanSchema.required().description('Does this message have a $Forwarded flag'),
+                                        keywords: Joi.array().items(Joi.string()).description('Custom keywords set on this message'),
                                         draft: booleanSchema.description('True if message is a draft').required(),
                                         contentType: Joi.object({
                                             value: Joi.string().required().description('MIME type of the message, eg. "multipart/mixed"'),
@@ -1022,8 +1030,13 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                 moveTo: Joi.string().hex().lowercase().length(24).description('ID of the target Mailbox if you want to move messages'),
                                 seen: booleanSchema.description('State of the \\Seen flag'),
                                 flagged: booleanSchema.description('State of the \\Flagged flag'),
-                                delete: booleanSchema.default(false).description('If true then delete all found messages')
+                                delete: booleanSchema.default(false).description('If true then delete all found messages'),
+                                keywords: keywordsSchema.description('Custom keywords to set on matched messages. Replaces all existing custom keywords.'),
+                                addKeywords: keywordsSchema.description('Custom keywords to add to matched messages without affecting existing keywords.'),
+                                removeKeywords: keywordsSchema.description('Custom keywords to remove from matched messages without affecting other keywords.')
                             })
+                            .oxor('keywords', 'addKeywords')
+                            .oxor('keywords', 'removeKeywords')
                             .custom((value, helpers) => {
                                 // If delete is set to true then any other field is disallowed to be set
                                 if (value.delete === true) {
@@ -1219,6 +1232,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                 params: Joi.object({}).description('An object with Content-Type params as key-value pairs')
                             }).description('Parsed Content-Type header. Usually needed to identify encrypted messages and such'),
                             metaData: Joi.alternatives().try(Joi.object({}), Joi.string()).description('Custom metadata object set for this message'),
+                            keywords: Joi.array().items(Joi.string()).description('Custom keywords set on this message'),
                             references: Joi.array().items(Joi.string()).required().description('References'),
                             files: Joi.array()
                                 .items(
@@ -1474,6 +1488,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 draft: messageData.draft,
                 answered: messageData.flags.includes('\\Answered') && !messageData.flags.includes('$Forwarded'),
                 forwarded: messageData.flags.includes('$Forwarded'),
+                keywords: extractKeywords(messageData.flags),
                 html: messageData.html,
                 text: messageData.text,
                 forwardTargets: messageData.forwardTargets,
@@ -1876,6 +1891,13 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         .try(Joi.date(), booleanSchema.allow(false))
                         .description('Either expiration date or false to turn off autoexpiration'),
                     metaData: metaDataSchema.label('metaData').description('Optional metadata, must be an object or JSON formatted string'),
+                    keywords: keywordsSchema.description('Custom keywords to set on the message, overrides any existing keywords'),
+                    addKeywords: keywordsSchema.description(
+                        'Custom keywords to add to the message without affecting existing keywords, can not be used together with `keywords`'
+                    ),
+                    removeKeywords: keywordsSchema.description(
+                        'Custom keywords to remove from the message without affecting other keywords, can not be used together with `keywords`'
+                    ),
 
                     sess: sessSchema,
                     ip: sessIPSchema
@@ -1935,6 +1957,11 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         .try(Joi.date(), booleanSchema.allow(false))
                         .description('Either expiration date or false to turn off autoexpiration'),
                     metaData: metaDataSchema.label('metaData').description('Optional metadata, must be an object or JSON formatted string'),
+                    keywords: keywordsSchema.description(
+                        'Custom keywords to set on the message. Replaces all existing custom keywords. System flags are not affected.'
+                    ),
+                    addKeywords: keywordsSchema.description('Custom keywords to add to the message without affecting existing keywords.'),
+                    removeKeywords: keywordsSchema.description('Custom keywords to remove from the message without affecting other keywords.'),
 
                     sess: sessSchema,
                     ip: sessIPSchema
@@ -2242,6 +2269,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     unseen: booleanSchema.default(false).description('Is the message unseen or not'),
                     flagged: booleanSchema.default(false).description('Is the message flagged or not'),
                     draft: booleanSchema.default(false).description('Is the message a draft or not'),
+                    keywords: keywordsSchema.description('Custom keywords to set on the uploaded message'),
 
                     raw: Joi.binary()
                         .max(consts.MAX_ALLOWED_MESSAGE_SIZE)
@@ -2638,7 +2666,8 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     flags: []
                         .concat('unseen' in result.value ? (result.value.unseen ? [] : '\\Seen') : [])
                         .concat('flagged' in result.value ? (result.value.flagged ? '\\Flagged' : []) : [])
-                        .concat('draft' in result.value ? (result.value.draft ? '\\Draft' : []) : []),
+                        .concat('draft' in result.value ? (result.value.draft ? '\\Draft' : []) : [])
+                        .concat(result.value.keywords || []),
                     raw,
                     referencedMessage: referencedMessage || false
                 });
@@ -3499,6 +3528,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                         draft: booleanSchema.required().description('is this message a draft'),
                                         answered: booleanSchema.required().description('Does this message have a Answered flag'),
                                         forwarded: booleanSchema.required().description('Does this message have a $Forwarded flag'),
+                                        keywords: Joi.array().items(Joi.string()).description('Custom keywords set on this message'),
                                         references: Joi.array().items(Joi.string()).required().description('References'),
                                         bimi: Joi.object({
                                             certified: booleanSchema.description('If true, then this logo is from a VMC file'),
@@ -4285,6 +4315,7 @@ function formatMessageListing(messageData, includeHeaders) {
         draft: messageData.draft,
         answered: messageData.flags.includes('\\Answered') && !messageData.flags.includes('$Forwarded'),
         forwarded: messageData.flags.includes('$Forwarded'),
+        keywords: extractKeywords(messageData.flags),
         references: (parsedHeader.references || '')
             .toString()
             .split(/\s+/)
@@ -4365,6 +4396,10 @@ function parseAddresses(data) {
     };
     walk([].concat(data || []));
     return Array.from(addresses);
+}
+
+function extractKeywords(flags) {
+    return (flags || []).filter(flag => !consts.SYSTEM_FLAGS.has(flag));
 }
 
 function getAttachmentCharset(mimeTree, attachmentId) {

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -61,6 +61,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
     const getMailboxCounter = tools.getMailboxCounter;
     const getKeywordCounter = tools.getKeywordCounter;
+    const getFlaggedCounter = tools.getFlaggedCounter;
     const extractKeywords = tools.extractKeywords;
     const asyncForward = util.promisify(forward);
 
@@ -215,6 +216,87 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             return res.json({
                 success: true,
                 keyword,
+                total,
+                unseen
+            });
+        })
+    );
+
+    server.get(
+        {
+            path: '/users/:user/flagged-counter',
+            summary: 'Get flagged counter',
+            name: 'getFlaggedCounter',
+            description: 'Returns total and unseen counters for flagged messages',
+            validationObjs: {
+                requestBody: {},
+                pathParams: {
+                    user: Joi.string().hex().lowercase().length(24).required().description('ID of the User')
+                },
+                queryParams: {
+                    sess: sessSchema,
+                    ip: sessIPSchema
+                },
+                response: {
+                    200: {
+                        description: 'Success',
+                        model: Joi.object({
+                            success: booleanSchema.required(),
+                            total: Joi.number().required().description('Total number of flagged messages'),
+                            unseen: Joi.number().required().description('Unseen number of flagged messages')
+                        }).$_setFlag('objectName', 'FlaggedCounterResponse')
+                    }
+                }
+            },
+            tags: ['Messages']
+        },
+        tools.responseWrapper(async (req, res) => {
+            res.charSet('utf-8');
+
+            const { requestBody, queryParams, pathParams } = req.route.spec.validationObjs;
+
+            const schema = Joi.object({
+                ...requestBody,
+                ...queryParams,
+                ...pathParams
+            });
+
+            const result = schema.validate(req.params, {
+                abortEarly: false,
+                convert: true,
+                allowUnknown: true
+            });
+
+            if (result.error) {
+                res.status(400);
+                return res.json({
+                    error: result.error.message,
+                    code: 'InputValidationError',
+                    details: tools.validationErrors(result)
+                });
+            }
+
+            if (req.user && req.user === result.value.user) {
+                req.validate(roles.can(req.role).readOwn('messages'));
+            } else {
+                req.validate(roles.can(req.role).readAny('messages'));
+            }
+
+            const user = new ObjectId(result.value.user);
+
+            const userExists = await db.users.collection('users').countDocuments({ _id: user }, { limit: 1 });
+            if (!userExists) {
+                res.status(404);
+                return res.json({
+                    error: 'This user does not exist',
+                    code: 'UserNotFound'
+                });
+            }
+
+            const [total, unseen] = await Promise.all([getFlaggedCounter(db, user), getFlaggedCounter(db, user, 'unseen')]);
+
+            return res.json({
+                success: true,
                 total,
                 unseen
             });

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -43,7 +43,7 @@ const { mongopagingFindWrapper } = require('../mongopaging-find-wrapper');
 const keywordsSchema = Joi.array().items(
     Joi.string()
         .max(255)
-        .regex(/^[^\s\\(){%*"[\]]+$/)
+        .regex(/^[^\s"%()*[\\\]{]+$/)
 );
 
 module.exports = (db, server, messageHandler, userHandler, storageHandler, settingsHandler) => {
@@ -66,6 +66,8 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
     const updateMessage = util.promisify(messageHandler.update.bind(messageHandler));
 
     const getMailboxCounter = tools.getMailboxCounter;
+    const getKeywordCounter = tools.getKeywordCounter;
+    const extractKeywords = tools.extractKeywords;
     const asyncForward = util.promisify(forward);
 
     const addThreadCountersToMessageList = async (user, list, collection = 'messages') => {
@@ -136,6 +138,94 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             }
         }
     };
+
+    server.get(
+        {
+            path: '/users/:user/keyword-counters/:keyword',
+            summary: 'Get keyword counter',
+            name: 'getKeywordCounters',
+            description: 'Returns total and unseen counters for a custom keyword',
+            validationObjs: {
+                requestBody: {},
+                pathParams: {
+                    user: Joi.string().hex().lowercase().length(24).required().description('ID of the User'),
+                    keyword: Joi.string().max(100).required().description('Keyword to count')
+                },
+                queryParams: {
+                    sess: sessSchema,
+                    ip: sessIPSchema
+                },
+                response: {
+                    200: {
+                        description: 'Success',
+                        model: Joi.object({
+                            success: booleanSchema.required(),
+                            keyword: Joi.string().required().description('Keyword name'),
+                            total: Joi.number().required().description('Total number of messages with this keyword'),
+                            unseen: Joi.number().required().description('Unseen number of messages with this keyword')
+                        }).$_setFlag('objectName', 'KeywordCounterResponse')
+                    }
+                }
+            },
+            tags: ['Messages']
+        },
+        tools.responseWrapper(async (req, res) => {
+            res.charSet('utf-8');
+
+            const { requestBody, queryParams, pathParams } = req.route.spec.validationObjs;
+
+            const schema = Joi.object({
+                ...requestBody,
+                ...queryParams,
+                ...pathParams
+            });
+
+            const result = schema.validate(req.params, {
+                abortEarly: false,
+                convert: true,
+                allowUnknown: true
+            });
+
+            if (result.error) {
+                res.status(400);
+                return res.json({
+                    error: result.error.message,
+                    code: 'InputValidationError',
+                    details: tools.validationErrors(result)
+                });
+            }
+
+            if (req.user && req.user === result.value.user) {
+                req.validate(roles.can(req.role).readOwn('messages'));
+            } else {
+                req.validate(roles.can(req.role).readAny('messages'));
+            }
+
+            const user = new ObjectId(result.value.user);
+            const keyword = result.value.keyword;
+
+            const userExists = await db.users.collection('users').countDocuments({ _id: user }, { limit: 1 });
+            if (!userExists) {
+                res.status(404);
+                return res.json({
+                    error: 'This user does not exist',
+                    code: 'UserNotFound'
+                });
+            }
+
+            const [total, unseen] = await Promise.all([
+                getKeywordCounter(db, user, keyword),
+                getKeywordCounter(db, user, keyword, 'unseen')
+            ]);
+
+            return res.json({
+                success: true,
+                keyword,
+                total,
+                unseen
+            });
+        })
+    );
 
     const putMessageHandler = async (req, res) => {
         res.charSet('utf-8');
@@ -4315,7 +4405,7 @@ function formatMessageListing(messageData, includeHeaders) {
         draft: messageData.draft,
         answered: messageData.flags.includes('\\Answered') && !messageData.flags.includes('$Forwarded'),
         forwarded: messageData.flags.includes('$Forwarded'),
-        keywords: extractKeywords(messageData.flags),
+        keywords: tools.extractKeywords(messageData.flags),
         references: (parsedHeader.references || '')
             .toString()
             .split(/\s+/)
@@ -4396,10 +4486,6 @@ function parseAddresses(data) {
     };
     walk([].concat(data || []));
     return Array.from(addresses);
-}
-
-function extractKeywords(flags) {
-    return (flags || []).filter(flag => !consts.SYSTEM_FLAGS.has(flag));
 }
 
 function getAttachmentCharset(mimeTree, attachmentId) {

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -2833,7 +2833,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         .concat('unseen' in result.value ? (result.value.unseen ? [] : '\\Seen') : [])
                         .concat('flagged' in result.value ? (result.value.flagged ? '\\Flagged' : []) : [])
                         .concat('draft' in result.value ? (result.value.draft ? '\\Draft' : []) : [])
-                        .concat(result.value.keywords || []),
+                        .concat(result.value.keywords ?? []),
                     raw,
                     referencedMessage: referencedMessage || false
                 });

--- a/lib/api/updates.js
+++ b/lib/api/updates.js
@@ -451,75 +451,78 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
     let changedKeywords = new Set();
     let flaggedChanged = false;
 
-    let emitFlaggedCounter = next => {
+    let emitFlaggedCounter = async next => {
         if (!flaggedChanged) {
             return next();
         }
 
-        Promise.all([tools.getFlaggedCounter(db, user), tools.getFlaggedCounter(db, user, 'unseen')])
-            .then(([total, unseen]) => {
-                res.write(
-                    formatJournalData({
-                        command: 'FLAGGED_COUNTER',
-                        _id: lastEventId,
-                        total,
-                        unseen
-                    })
-                );
-                next();
-            })
-            .catch(() => next());
+        try {
+            const [total, unseen] = await Promise.all([tools.getFlaggedCounter(db, user), tools.getFlaggedCounter(db, user, 'unseen')]);
+            res.write(
+                formatJournalData({
+                    command: 'FLAGGED_COUNTER',
+                    _id: lastEventId,
+                    total,
+                    unseen
+                })
+            );
+        } catch {
+            // ignore
+        }
+        next();
     };
 
-    let emitKeywordCounters = next => {
+    let emitKeywordCounters = async next => {
         if (!changedKeywords.size) {
             return next();
         }
 
-        const userKey = user.toString();
-        Promise.all(
-            [...changedKeywords].map(async keyword => {
-                const isCached = await db.redis.exists(`kw:total:${userKey}:${keyword}`);
-                return isCached ? keyword : null;
-            })
-        )
-            .then(async results => {
-                const toEmit = results.filter(Boolean);
-                if (!toEmit.length) {
-                    return next();
-                }
+        try {
+            const userKey = user.toString();
+            const cachedResults = await Promise.all(
+                [...changedKeywords].map(async keyword => {
+                    const isCached = await db.redis.exists(`kw:total:${userKey}:${keyword}`);
+                    return isCached ? keyword : null;
+                })
+            );
 
-                const keywordResults = await Promise.all(
-                    toEmit.map(async keyword => {
-                        let total, unseen;
-                        try {
-                            total = await tools.getKeywordCounter(db, user, keyword);
-                        } catch {
-                            total = 0;
-                        }
-                        try {
-                            unseen = await tools.getKeywordCounter(db, user, keyword, 'unseen');
-                        } catch {
-                            unseen = 0;
-                        }
-                        return { keyword, total, unseen };
-                    })
-                );
+            const toEmit = cachedResults.filter(Boolean);
+            if (!toEmit.length) {
+                return next();
+            }
 
-                for (const { keyword, total, unseen } of keywordResults) {
-                    let keywordEntry = {
-                        command: 'KEYWORD_COUNTERS',
-                        _id: lastEventId,
-                        keyword,
-                        total,
-                        unseen
-                    };
-                    res.write(formatJournalData(keywordEntry));
-                    onEntry('keyword-counters', keywordEntry);
-                }
-                next();
-            })
-            .catch(() => next());
+            const keywordResults = await Promise.all(
+                toEmit.map(async keyword => {
+                    let total, unseen;
+                    try {
+                        total = await tools.getKeywordCounter(db, user, keyword);
+                    } catch {
+                        total = 0;
+                    }
+                    try {
+                        unseen = await tools.getKeywordCounter(db, user, keyword, 'unseen');
+                    } catch {
+                        unseen = 0;
+                    }
+                    return { keyword, total, unseen };
+                })
+            );
+
+            for (const { keyword, total, unseen } of keywordResults) {
+                let keywordEntry = {
+                    command: 'KEYWORD_COUNTERS',
+                    _id: lastEventId,
+                    keyword,
+                    total,
+                    unseen
+                };
+                res.write(formatJournalData(keywordEntry));
+                onEntry('keyword-counters', keywordEntry);
+            }
+        } catch {
+            // ignore
+        }
+        next();
     };
 
     let cursor = db.database.collection('journal').find(query).sort({ _id: 1 });
@@ -612,6 +615,26 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
                     break;
             }
 
+            let writeEntryAndContinue = () => {
+                try {
+                    let data = formatJournalData(e);
+                    res.write(data);
+                    onEntry('replay', e);
+                } catch (err) {
+                    log.error(
+                        'API',
+                        'action=updates-event-write-fail user=%s event=%s payload=%s error=%s',
+                        user.toString(),
+                        formatLogValue(e.command),
+                        stringifyJournalPayload(e),
+                        err.stack || err
+                    );
+                }
+
+                processed++;
+                return setImmediate(processNext);
+            };
+
             for (const keyword of [...(e.keywords ?? []), ...(e.addedKeywords ?? []), ...(e.removedKeywords ?? [])]) {
                 changedKeywords.add(keyword);
             }
@@ -624,23 +647,7 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
                 }
             }
 
-            try {
-                let data = formatJournalData(e);
-                res.write(data);
-                onEntry('replay', e);
-            } catch (err) {
-                log.error(
-                    'API',
-                    'action=updates-event-write-fail user=%s event=%s payload=%s error=%s',
-                    user.toString(),
-                    formatLogValue(e.command),
-                    stringifyJournalPayload(e),
-                    err.stack || err
-                );
-            }
-
-            processed++;
-            return setImmediate(processNext);
+            writeEntryAndContinue();
         });
     };
 

--- a/lib/api/updates.js
+++ b/lib/api/updates.js
@@ -23,7 +23,7 @@ const hasUpdatesStreamLogging = !!(config.log && config.log.updateStream);
 
 const formatLogValue = value => String(value);
 
-const COUNTER_COMMANDS = new Set(['COUNTERS', 'KEYWORD_COUNTERS']);
+const COUNTER_COMMANDS = new Set(['COUNTERS', 'KEYWORD_COUNTERS', 'FLAGGED_COUNTER']);
 
 const getJournalPayload = entry => {
     const data = {};
@@ -449,6 +449,27 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
 
     let mailboxes = new Set();
     let changedKeywords = new Set();
+    let flaggedChanged = false;
+
+    let emitFlaggedCounter = next => {
+        if (!flaggedChanged) {
+            return next();
+        }
+
+        Promise.all([tools.getFlaggedCounter(db, user), tools.getFlaggedCounter(db, user, 'unseen')])
+            .then(([total, unseen]) => {
+                res.write(
+                    formatJournalData({
+                        command: 'FLAGGED_COUNTER',
+                        _id: lastEventId,
+                        total,
+                        unseen
+                    })
+                );
+                next();
+            })
+            .catch(() => next());
+    };
 
     let emitKeywordCounters = next => {
         if (!changedKeywords.size) {
@@ -511,11 +532,13 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
             if (!e) {
                 return cursor.close(() => {
                     let finalize = () =>
-                        emitKeywordCounters(() =>
-                            done(null, {
-                                lastEventId,
-                                processed
-                            })
+                        emitFlaggedCounter(() =>
+                            emitKeywordCounters(() =>
+                                done(null, {
+                                    lastEventId,
+                                    processed
+                                })
+                            )
                         );
 
                     if (!mailboxes.size) {
@@ -570,10 +593,21 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
                     if (e.mailbox) {
                         mailboxes.add(e.mailbox.toString());
                     }
+                    if (e.flagged) {
+                        flaggedChanged = true;
+                    }
                     break;
                 case 'FETCH':
                     if (e.mailbox && (e.unseen || e.unseenChange)) {
                         mailboxes.add(e.mailbox.toString());
+                    }
+
+                    if (e.flaggedChangedTo === true || e.flaggedChangedTo === false) {
+                        flaggedChanged = true;
+                    }
+
+                    if (e.unseenChange && (e.flags ?? []).includes('\\Flagged')) {
+                        flaggedChanged = true;
                     }
                     break;
             }

--- a/lib/api/updates.js
+++ b/lib/api/updates.js
@@ -6,6 +6,7 @@ const Joi = require('joi');
 const ObjectId = require('mongodb').ObjectId;
 const log = require('npmlog');
 const tools = require('../tools');
+const consts = require('../consts');
 const roles = require('../roles');
 const base32 = require('base32.js');
 const { sessSchema, sessIPSchema } = require('../schemas');
@@ -22,11 +23,13 @@ const hasUpdatesStreamLogging = !!(config.log && config.log.updateStream);
 
 const formatLogValue = value => String(value);
 
+const COUNTER_COMMANDS = new Set(['COUNTERS', 'KEYWORD_COUNTERS']);
+
 const getJournalPayload = entry => {
     const data = {};
     Object.keys(entry).forEach(key => {
         if (!['_id', 'ignore', 'user', 'modseq', 'unseenChange', 'created'].includes(key)) {
-            if (entry.command !== 'COUNTERS' && key === 'unseen') {
+            if (!COUNTER_COMMANDS.has(entry.command) && key === 'unseen') {
                 return;
             }
             data[key] = entry[key];
@@ -63,6 +66,22 @@ const logUpdatesEvent = (session, source, entry) => {
             entry.command,
             formatLogValue(entry._id),
             formatLogValue(entry.mailbox),
+            formatLogValue(entry.total),
+            formatLogValue(entry.unseen),
+            payload
+        );
+    }
+
+    if (entry.command === 'KEYWORD_COUNTERS') {
+        return log.verbose(
+            'API',
+            '[%s] action=updates-event source=%s user=%s event=%s eventId=%s keyword=%s total=%s unseen=%s payload=%s',
+            session.id,
+            source,
+            formatLogValue(session.user.id),
+            entry.command,
+            formatLogValue(entry._id),
+            formatLogValue(entry.keyword),
             formatLogValue(entry.total),
             formatLogValue(entry.unseen),
             payload
@@ -429,6 +448,58 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
     }
 
     let mailboxes = new Set();
+    let changedKeywords = new Set();
+
+    let emitKeywordCounters = next => {
+        if (!changedKeywords.size) {
+            return next();
+        }
+
+        const userKey = user.toString();
+        Promise.all(
+            [...changedKeywords].map(async keyword => {
+                const isCached = await db.redis.exists(`kw:total:${userKey}:${keyword}`);
+                return isCached ? keyword : null;
+            })
+        )
+            .then(async results => {
+                const toEmit = results.filter(Boolean);
+                if (!toEmit.length) {
+                    return next();
+                }
+
+                const keywordResults = await Promise.all(
+                    toEmit.map(async keyword => {
+                        let total, unseen;
+                        try {
+                            total = await tools.getKeywordCounter(db, user, keyword);
+                        } catch {
+                            total = 0;
+                        }
+                        try {
+                            unseen = await tools.getKeywordCounter(db, user, keyword, 'unseen');
+                        } catch {
+                            unseen = 0;
+                        }
+                        return { keyword, total, unseen };
+                    })
+                );
+
+                for (const { keyword, total, unseen } of keywordResults) {
+                    let keywordEntry = {
+                        command: 'KEYWORD_COUNTERS',
+                        _id: lastEventId,
+                        keyword,
+                        total,
+                        unseen
+                    };
+                    res.write(formatJournalData(keywordEntry));
+                    onEntry('keyword-counters', keywordEntry);
+                }
+                next();
+            })
+            .catch(() => next());
+    };
 
     let cursor = db.database.collection('journal').find(query).sort({ _id: 1 });
     let processed = 0;
@@ -439,21 +510,23 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
             }
             if (!e) {
                 return cursor.close(() => {
+                    let finalize = () =>
+                        emitKeywordCounters(() =>
+                            done(null, {
+                                lastEventId,
+                                processed
+                            })
+                        );
+
                     if (!mailboxes.size) {
-                        return done(null, {
-                            lastEventId,
-                            processed
-                        });
+                        return finalize();
                     }
 
                     mailboxes = Array.from(mailboxes);
                     let mailboxPos = 0;
                     let emitCounters = () => {
                         if (mailboxPos >= mailboxes.length) {
-                            return done(null, {
-                                lastEventId,
-                                processed
-                            });
+                            return finalize();
                         }
                         let mailbox = new ObjectId(mailboxes[mailboxPos++]);
                         getMailboxCounterCb(db, mailbox, false, (err, total) => {
@@ -503,6 +576,18 @@ function loadJournalStream(db, res, user, lastEventId, done, onEntry) {
                         mailboxes.add(e.mailbox.toString());
                     }
                     break;
+            }
+
+            for (const keyword of [...(e.keywords ?? []), ...(e.addedKeywords ?? []), ...(e.removedKeywords ?? [])]) {
+                changedKeywords.add(keyword);
+            }
+
+            if (e.unseenChange) {
+                for (const flag of e.flags ?? []) {
+                    if (flag && !consts.SYSTEM_FLAGS.has(flag)) {
+                        changedKeywords.add(flag);
+                    }
+                }
             }
 
             try {

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -26,6 +26,7 @@ module.exports = {
     DELETED_USER_MESSAGE_RETENTION: 14 * 24 * 3600 * 1000,
 
     MAILBOX_COUNTER_TTL: 24 * 3600,
+    KEYWORD_COUNTER_TTL: 24 * 3600,
 
     // how much plaintext to store in a full text indexed field
     MAX_PLAINTEXT_INDEXED: 1 * 1024,

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -151,5 +151,8 @@ module.exports = {
     // Both are legacy and potentially vulnerable.
     // Prefer AES-GCM + OAEP for modern deployments with capable clients.
     SMIME_DEFAULT_CIPHER: 'AES-CBC',
-    SMIME_DEFAULT_RSA_KEY_TRANSPORT: 'PKCS#1 v1.5'
+    SMIME_DEFAULT_RSA_KEY_TRANSPORT: 'PKCS#1 v1.5',
+
+    // System IMAP flags and internal pseudo-flags that are not custom keywords
+    SYSTEM_FLAGS: new Set(['\\Answered', '\\Flagged', '\\Draft', '\\Deleted', '\\Seen', '$Forwarded'])
 };

--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -289,8 +289,8 @@ class FilterHandler {
                 }
 
                 if (key === 'keywords') {
-                    let existingKeywords = filterActions.get('keywords') || [];
-                    let newKeywords = filterData.action[key] || [];
+                    let existingKeywords = filterActions.get('keywords') ?? [];
+                    let newKeywords = filterData.action[key] ?? [];
                     filterActions.set('keywords', [...new Set([...existingKeywords, ...newKeywords])]);
                     return;
                 }
@@ -705,11 +705,11 @@ class FilterHandler {
                     break;
                 case 'keywords':
                     if (Array.isArray(value) && value.length) {
-                        value.forEach(keyword => {
+                        for (let keyword of value) {
                             if (!flags.includes(keyword)) {
                                 flags.push(keyword);
                             }
-                        });
+                        }
                         filterResults.push({ keywords: value });
                     }
                     break;

--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -288,6 +288,13 @@ class FilterHandler {
                     return;
                 }
 
+                if (key === 'keywords') {
+                    let existingKeywords = filterActions.get('keywords') || [];
+                    let newKeywords = filterData.action[key] || [];
+                    filterActions.set('keywords', [...new Set([...existingKeywords, ...newKeywords])]);
+                    return;
+                }
+
                 if (key === 'spam' && filterData.action[key] === null) {
                     return;
                 }
@@ -694,6 +701,16 @@ class FilterHandler {
                     if (value) {
                         flags.push('\\Flagged');
                         filterResults.push({ flagged: true });
+                    }
+                    break;
+                case 'keywords':
+                    if (Array.isArray(value) && value.length) {
+                        value.forEach(keyword => {
+                            if (!flags.includes(keyword)) {
+                                flags.push(keyword);
+                            }
+                        });
+                        filterResults.push({ keywords: value });
                     }
                     break;
                 case 'mailbox':

--- a/lib/handlers/on-copy.js
+++ b/lib/handlers/on-copy.js
@@ -294,6 +294,7 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                 uid: messageData.uid,
                 message: messageData._id,
                 unseen: messageData.unseen,
+                flagged: messageData.flagged,
                 idate: messageData.idate,
                 thread: messageData.thread
             };

--- a/lib/handlers/on-copy.js
+++ b/lib/handlers/on-copy.js
@@ -295,6 +295,7 @@ async function copyHandler(server, messageHandler, connection, mailbox, update, 
                 message: messageData._id,
                 unseen: messageData.unseen,
                 flagged: messageData.flagged,
+                keywords: tools.extractKeywords(messageData.flags),
                 idate: messageData.idate,
                 thread: messageData.thread
             };

--- a/lib/handlers/on-store.js
+++ b/lib/handlers/on-store.js
@@ -153,6 +153,7 @@ module.exports = server => (mailbox, update, session, callback) => {
 
                     let updated = false;
                     const oldKeywords = new Set(extractKeywords(message.flags));
+                    const messageWasFlagged = message.flags.includes('\\Flagged');
                     let existingFlags = message.flags.map(flag => flag.toLowerCase().trim());
                     switch (update.action) {
                         case 'set':
@@ -350,8 +351,9 @@ module.exports = server => (mailbox, update, session, callback) => {
                             const currentKeywords = extractKeywords(message.flags);
                             const addedKeywords = currentKeywords.filter(keyword => !oldKeywords.has(keyword));
                             const removedKeywords = Array.from(oldKeywords).filter(keyword => !currentKeywords.includes(keyword));
+                            const messageIsFlagged = message.flags.includes('\\Flagged');
 
-                            notifyEntries.push({
+                            const notifyEntry = {
                                 command: 'FETCH',
                                 ignore: session.id,
                                 uid: message.uid,
@@ -362,7 +364,13 @@ module.exports = server => (mailbox, update, session, callback) => {
                                 message: message._id,
                                 modseq,
                                 unseenChange
-                            });
+                            };
+
+                            if (messageWasFlagged !== messageIsFlagged) {
+                                notifyEntry.flaggedChangedTo = messageIsFlagged;
+                            }
+
+                            notifyEntries.push(notifyEntry);
 
                             if (updateEntries.length >= consts.BULK_BATCH_SIZE) {
                                 return db.database.collection('messages').bulkWrite(

--- a/lib/handlers/on-store.js
+++ b/lib/handlers/on-store.js
@@ -350,7 +350,7 @@ module.exports = server => (mailbox, update, session, callback) => {
 
                             const currentKeywords = extractKeywords(message.flags);
                             const addedKeywords = currentKeywords.filter(keyword => !oldKeywords.has(keyword));
-                            const removedKeywords = Array.from(oldKeywords).filter(keyword => !currentKeywords.includes(keyword));
+                            const removedKeywords = [...oldKeywords].filter(keyword => !currentKeywords.includes(keyword));
                             const messageIsFlagged = message.flags.includes('\\Flagged');
 
                             const notifyEntry = {

--- a/lib/handlers/on-store.js
+++ b/lib/handlers/on-store.js
@@ -4,6 +4,7 @@ const imapTools = require('../../imap-core/lib/imap-tools');
 const db = require('../db');
 const tools = require('../tools');
 const consts = require('../consts');
+const extractKeywords = tools.extractKeywords;
 
 // STORE / UID STORE, updates flags for selected UIDs
 module.exports = server => (mailbox, update, session, callback) => {
@@ -151,6 +152,7 @@ module.exports = server => (mailbox, update, session, callback) => {
                     let flagsupdate = false; // query object for updates
 
                     let updated = false;
+                    const oldKeywords = new Set(extractKeywords(message.flags));
                     let existingFlags = message.flags.map(flag => flag.toLowerCase().trim());
                     switch (update.action) {
                         case 'set':
@@ -345,11 +347,17 @@ module.exports = server => (mailbox, update, session, callback) => {
                                 }
                             });
 
+                            const currentKeywords = extractKeywords(message.flags);
+                            const addedKeywords = currentKeywords.filter(keyword => !oldKeywords.has(keyword));
+                            const removedKeywords = Array.from(oldKeywords).filter(keyword => !currentKeywords.includes(keyword));
+
                             notifyEntries.push({
                                 command: 'FETCH',
                                 ignore: session.id,
                                 uid: message.uid,
                                 flags: message.flags,
+                                addedKeywords,
+                                removedKeywords,
                                 thread: message.thread,
                                 message: message._id,
                                 modseq,

--- a/lib/imap-notifier.js
+++ b/lib/imap-notifier.js
@@ -266,6 +266,12 @@ class ImapNotifier extends EventEmitter {
                 this.logger.error('Failed to update keyword counters', err.message);
             }
 
+            try {
+                await this.updateFlaggedCounters(entries);
+            } catch (err) {
+                this.logger.error('Failed to update flagged counters', err.message);
+            }
+
             return r.insertedCount;
         };
 
@@ -629,6 +635,97 @@ class ImapNotifier extends EventEmitter {
         }
 
         await this.applyKeywordDeltas(user.toString(), deltas);
+    }
+
+    collectFlaggedDelta(entries) {
+        const delta = { total: 0, unseen: 0 };
+
+        for (let entry of entries) {
+            if (!entry) {
+                continue;
+            }
+
+            switch (entry.command) {
+                case 'EXISTS':
+                    if (entry.flagged) {
+                        delta.total += 1;
+                        if (entry.unseen) {
+                            delta.unseen += 1;
+                        }
+                    }
+                    break;
+
+                case 'EXPUNGE':
+                    if (entry.flagged) {
+                        delta.total -= 1;
+                        if (entry.unseen) {
+                            delta.unseen -= 1;
+                        }
+                    }
+                    break;
+
+                case 'FETCH': {
+                    const messageUnseen = !(entry.flags ?? []).includes('\\Seen');
+                    const messageFlagged = (entry.flags ?? []).includes('\\Flagged');
+
+                    if (entry.flaggedChangedTo === true) {
+                        delta.total += 1;
+                        if (messageUnseen) {
+                            delta.unseen += 1;
+                        }
+                    } else if (entry.flaggedChangedTo === false) {
+                        delta.total -= 1;
+                        if (messageUnseen) {
+                            delta.unseen -= 1;
+                        }
+                    }
+
+                    if (entry.unseenChange && messageFlagged) {
+                        delta.unseen += messageUnseen ? 1 : -1;
+                    }
+                    break;
+                }
+            }
+        }
+
+        return delta;
+    }
+
+    async applyFlaggedDelta(userKey, delta) {
+        if (delta.total) {
+            const totalKey = `fl:total:${userKey}`;
+            if (await this.redis.exists(totalKey)) {
+                await this.redis.cachedcounter(totalKey, delta.total, consts.KEYWORD_COUNTER_TTL);
+            }
+        }
+
+        if (delta.unseen) {
+            const unseenKey = `fl:unseen:${userKey}`;
+            if (await this.redis.exists(unseenKey)) {
+                await this.redis.cachedcounter(unseenKey, delta.unseen, consts.KEYWORD_COUNTER_TTL);
+            }
+        }
+    }
+
+    async updateFlaggedCounters(entries) {
+        let list = [];
+        if (Array.isArray(entries)) {
+            list = entries;
+        } else if (entries) {
+            list = [entries];
+        }
+
+        const user = list[0]?.user;
+        if (!user) {
+            return;
+        }
+
+        const delta = this.collectFlaggedDelta(list);
+        if (!delta.total && !delta.unseen) {
+            return;
+        }
+
+        await this.applyFlaggedDelta(user.toString(), delta);
     }
 
     allocateConnection(data, callback) {

--- a/lib/imap-notifier.js
+++ b/lib/imap-notifier.js
@@ -539,11 +539,6 @@ class ImapNotifier extends EventEmitter {
         }
     }
 
-    getTrackedEntryKeywords(entryKeywords) {
-        const keywords = entryKeywords ?? [];
-        return [...new Set(keywords.filter(keyword => keyword && !consts.SYSTEM_FLAGS.has(keyword)))];
-    }
-
     addKeywordDelta(deltas, keyword, total, unseen) {
         if (!deltas.has(keyword)) {
             deltas.set(keyword, { total: 0, unseen: 0 });
@@ -563,13 +558,13 @@ class ImapNotifier extends EventEmitter {
 
             switch (entry.command) {
                 case 'EXISTS':
-                    for (let keyword of this.getTrackedEntryKeywords(entry.keywords)) {
+                    for (let keyword of tools.extractKeywords(entry.keywords)) {
                         this.addKeywordDelta(deltas, keyword, 1, entry.unseen ? 1 : 0);
                     }
                     break;
 
                 case 'EXPUNGE':
-                    for (let keyword of this.getTrackedEntryKeywords(entry.keywords)) {
+                    for (let keyword of tools.extractKeywords(entry.keywords)) {
                         this.addKeywordDelta(deltas, keyword, -1, entry.unseen ? -1 : 0);
                     }
                     break;
@@ -577,17 +572,17 @@ class ImapNotifier extends EventEmitter {
                 case 'FETCH': {
                     const messageUnseen = !(entry.flags ?? []).includes('\\Seen');
 
-                    for (let keyword of this.getTrackedEntryKeywords(entry.addedKeywords)) {
+                    for (let keyword of tools.extractKeywords(entry.addedKeywords)) {
                         this.addKeywordDelta(deltas, keyword, 1, messageUnseen ? 1 : 0);
                     }
 
-                    for (let keyword of this.getTrackedEntryKeywords(entry.removedKeywords)) {
+                    for (let keyword of tools.extractKeywords(entry.removedKeywords)) {
                         this.addKeywordDelta(deltas, keyword, -1, messageUnseen ? -1 : 0);
                     }
 
                     if (entry.unseenChange) {
                         const unseenStep = messageUnseen ? 1 : -1;
-                        for (let keyword of this.getTrackedEntryKeywords(entry.flags)) {
+                        for (let keyword of tools.extractKeywords(entry.flags)) {
                             this.addKeywordDelta(deltas, keyword, 0, unseenStep);
                         }
                     }

--- a/lib/imap-notifier.js
+++ b/lib/imap-notifier.js
@@ -260,6 +260,12 @@ class ImapNotifier extends EventEmitter {
                 this.logger.error('Failed to update mailbox counters', err.message);
             }
 
+            try {
+                await this.updateKeywordCounters(entries);
+            } catch (err) {
+                this.logger.error('Failed to update keyword counters', err.message);
+            }
+
             return r.insertedCount;
         };
 
@@ -525,6 +531,104 @@ class ImapNotifier extends EventEmitter {
                 await this.redis.cachedcounter(`unseen:${mailbox}`, delta.unseen, consts.MAILBOX_COUNTER_TTL);
             }
         }
+    }
+
+    getTrackedEntryKeywords(entryKeywords) {
+        const keywords = entryKeywords ?? [];
+        return [...new Set(keywords.filter(keyword => keyword && !consts.SYSTEM_FLAGS.has(keyword)))];
+    }
+
+    addKeywordDelta(deltas, keyword, total, unseen) {
+        if (!deltas.has(keyword)) {
+            deltas.set(keyword, { total: 0, unseen: 0 });
+        }
+        const delta = deltas.get(keyword);
+        delta.total += total;
+        delta.unseen += unseen;
+    }
+
+    collectKeywordDeltas(entries) {
+        const deltas = new Map();
+
+        for (let entry of entries) {
+            if (!entry) {
+                continue;
+            }
+
+            switch (entry.command) {
+                case 'EXISTS':
+                    for (let keyword of this.getTrackedEntryKeywords(entry.keywords)) {
+                        this.addKeywordDelta(deltas, keyword, 1, entry.unseen ? 1 : 0);
+                    }
+                    break;
+
+                case 'EXPUNGE':
+                    for (let keyword of this.getTrackedEntryKeywords(entry.keywords)) {
+                        this.addKeywordDelta(deltas, keyword, -1, entry.unseen ? -1 : 0);
+                    }
+                    break;
+
+                case 'FETCH': {
+                    const messageUnseen = !(entry.flags ?? []).includes('\\Seen');
+
+                    for (let keyword of this.getTrackedEntryKeywords(entry.addedKeywords)) {
+                        this.addKeywordDelta(deltas, keyword, 1, messageUnseen ? 1 : 0);
+                    }
+
+                    for (let keyword of this.getTrackedEntryKeywords(entry.removedKeywords)) {
+                        this.addKeywordDelta(deltas, keyword, -1, messageUnseen ? -1 : 0);
+                    }
+
+                    if (entry.unseenChange) {
+                        const unseenStep = messageUnseen ? 1 : -1;
+                        for (let keyword of this.getTrackedEntryKeywords(entry.flags)) {
+                            this.addKeywordDelta(deltas, keyword, 0, unseenStep);
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        return deltas;
+    }
+
+    async applyKeywordDeltas(userKey, deltas) {
+        for (let [keyword, delta] of deltas) {
+            if (delta.total) {
+                const totalKey = `kw:total:${userKey}:${keyword}`;
+                if (await this.redis.exists(totalKey)) {
+                    await this.redis.cachedcounter(totalKey, delta.total, consts.KEYWORD_COUNTER_TTL);
+                }
+            }
+            if (delta.unseen) {
+                const unseenKey = `kw:unseen:${userKey}:${keyword}`;
+                if (await this.redis.exists(unseenKey)) {
+                    await this.redis.cachedcounter(unseenKey, delta.unseen, consts.KEYWORD_COUNTER_TTL);
+                }
+            }
+        }
+    }
+
+    async updateKeywordCounters(entries) {
+        let list = [];
+        if (Array.isArray(entries)) {
+            list = entries;
+        } else if (entries) {
+            list = [entries];
+        }
+
+        const user = list[0]?.user;
+        if (!user) {
+            return;
+        }
+
+        const deltas = this.collectKeywordDeltas(list);
+        if (!deltas.size) {
+            return;
+        }
+
+        await this.applyKeywordDeltas(user.toString(), deltas);
     }
 
     allocateConnection(data, callback) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -642,6 +642,7 @@ class MessageHandler {
                             message: messageData._id,
                             modseq: messageData.modseq,
                             unseen: messageData.unseen,
+                            flagged: messageData.flagged,
                             keywords: tools.extractKeywords(messageData.flags),
                             idate: messageData.idate,
                             thread: messageData.thread
@@ -913,6 +914,7 @@ class MessageHandler {
                         uid: messageData.uid,
                         message: messageData._id,
                         unseen: messageData.unseen,
+                        flagged: messageData.flagged,
                         keywords: tools.extractKeywords(messageData.flags),
                         thread: messageData.thread
                     },
@@ -1322,6 +1324,7 @@ class MessageHandler {
                             uid: uidNext,
                             message: insertId,
                             unseen: messageData.unseen,
+                            flagged: messageData.flags.includes('\\Flagged'),
                             keywords: tools.extractKeywords(messageData.flags),
                             idate: messageData.idate,
                             thread: messageData.thread
@@ -1767,13 +1770,15 @@ class MessageHandler {
                                 const newKeywords = new Set(tools.extractKeywords(updatedMessageData.flags));
                                 const messageWasSeen = (messageData.flags || []).includes('\\Seen');
                                 const messageIsSeen = (updatedMessageData.flags || []).includes('\\Seen');
+                                const messageWasFlagged = (messageData.flags || []).includes('\\Flagged');
+                                const messageIsFlagged = (updatedMessageData.flags || []).includes('\\Flagged');
 
                                 const addedKeywords = Array.from(newKeywords).filter(keyword => !oldKeywords.has(keyword));
                                 const removedKeywords = Array.from(oldKeywords).filter(keyword => !newKeywords.has(keyword));
 
                                 updatedCount++;
 
-                                notifyEntries.push({
+                                const notifyEntry = {
                                     command: 'FETCH',
                                     uid: updatedMessageData.uid,
                                     flags: updatedMessageData.flags,
@@ -1782,7 +1787,13 @@ class MessageHandler {
                                     thread: updatedMessageData.thread,
                                     message: updatedMessageData._id,
                                     unseenChange: messageWasSeen !== messageIsSeen
-                                });
+                                };
+
+                                if (messageWasFlagged !== messageIsFlagged) {
+                                    notifyEntry.flaggedChangedTo = messageIsFlagged;
+                                }
+
+                                notifyEntries.push(notifyEntry);
 
                                 if (notifyEntries.length >= bulk_batch_size) {
                                     return this.notifier.addEntries(mailboxData, notifyEntries, () => {
@@ -2259,6 +2270,7 @@ class MessageHandler {
                 message: messageId,
                 thread: message.thread,
                 unseen,
+                flagged: message.flags.includes('\\Flagged'),
                 keywords: tools.extractKeywords(message.flags),
                 // modseq is needed to avoid updating mailbox entry
                 modseq: newModseq
@@ -2274,6 +2286,7 @@ class MessageHandler {
             uid: uidNext,
             message: insertId,
             unseen: message.unseen,
+            flagged: message.flags.includes('\\Flagged'),
             keywords: tools.extractKeywords(message.flags),
             idate: message.idate,
             thread: message.thread

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1765,6 +1765,8 @@ class MessageHandler {
 
                                 const oldKeywords = new Set(tools.extractKeywords(messageData.flags));
                                 const newKeywords = new Set(tools.extractKeywords(updatedMessageData.flags));
+                                const messageWasSeen = (messageData.flags || []).includes('\\Seen');
+                                const messageIsSeen = (updatedMessageData.flags || []).includes('\\Seen');
 
                                 const addedKeywords = Array.from(newKeywords).filter(keyword => !oldKeywords.has(keyword));
                                 const removedKeywords = Array.from(oldKeywords).filter(keyword => !newKeywords.has(keyword));
@@ -1779,7 +1781,7 @@ class MessageHandler {
                                     removedKeywords,
                                     thread: updatedMessageData.thread,
                                     message: updatedMessageData._id,
-                                    unseenChange: 'seen' in changes
+                                    unseenChange: messageWasSeen !== messageIsSeen
                                 });
 
                                 if (notifyEntries.length >= bulk_batch_size) {

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1768,13 +1768,13 @@ class MessageHandler {
 
                                 const oldKeywords = new Set(tools.extractKeywords(messageData.flags));
                                 const newKeywords = new Set(tools.extractKeywords(updatedMessageData.flags));
-                                const messageWasSeen = (messageData.flags || []).includes('\\Seen');
-                                const messageIsSeen = (updatedMessageData.flags || []).includes('\\Seen');
-                                const messageWasFlagged = (messageData.flags || []).includes('\\Flagged');
-                                const messageIsFlagged = (updatedMessageData.flags || []).includes('\\Flagged');
+                                const messageWasSeen = (messageData.flags ?? []).includes('\\Seen');
+                                const messageIsSeen = (updatedMessageData.flags ?? []).includes('\\Seen');
+                                const messageWasFlagged = (messageData.flags ?? []).includes('\\Flagged');
+                                const messageIsFlagged = (updatedMessageData.flags ?? []).includes('\\Flagged');
 
-                                const addedKeywords = Array.from(newKeywords).filter(keyword => !oldKeywords.has(keyword));
-                                const removedKeywords = Array.from(oldKeywords).filter(keyword => !newKeywords.has(keyword));
+                                const addedKeywords = [...newKeywords].filter(keyword => !oldKeywords.has(keyword));
+                                const removedKeywords = [...oldKeywords].filter(keyword => !newKeywords.has(keyword));
 
                                 updatedCount++;
 

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1538,17 +1538,19 @@ class MessageHandler {
     }
 
     update(user, mailbox, messageQuery, changes, callback) {
-        let updates = { $set: {} };
+        let updates = {};
+        let unsetFields = [];
         let update = false;
         let addFlags = [];
         let removeFlags = [];
+        let removeNonSystemFlags = false;
 
         let notifyEntries = [];
 
         Object.keys(changes || {}).forEach(key => {
             switch (key) {
                 case 'seen':
-                    updates.$set.unseen = !changes.seen;
+                    updates.unseen = !changes.seen;
                     if (changes.seen) {
                         addFlags.push('\\Seen');
                     } else {
@@ -1558,7 +1560,7 @@ class MessageHandler {
                     break;
 
                 case 'deleted':
-                    updates.$set.undeleted = !changes.deleted;
+                    updates.undeleted = !changes.deleted;
                     if (changes.deleted) {
                         addFlags.push('\\Deleted');
                     } else {
@@ -1568,7 +1570,7 @@ class MessageHandler {
                     break;
 
                 case 'flagged':
-                    updates.$set.flagged = changes.flagged;
+                    updates.flagged = changes.flagged;
                     if (changes.flagged) {
                         addFlags.push('\\Flagged');
                     } else {
@@ -1578,7 +1580,7 @@ class MessageHandler {
                     break;
 
                 case 'draft':
-                    updates.$set.draft = changes.draft;
+                    updates.draft = changes.draft;
                     if (changes.draft) {
                         addFlags.push('\\Draft');
                     } else {
@@ -1589,20 +1591,34 @@ class MessageHandler {
 
                 case 'expires':
                     if (changes.expires) {
-                        updates.$set.exp = true;
-                        updates.$set.rdate = changes.expires.getTime();
+                        updates.exp = true;
+                        updates.rdate = changes.expires.getTime();
                     } else {
-                        updates.$set.exp = false;
-                        updates.$unset = updates.$unset || {};
-                        updates.$unset.rdate = true;
+                        updates.exp = false;
+                        unsetFields.push('rdate');
                     }
-                    updates.$unset = updates.$unset || {};
-                    updates.$unset.retention = true;
+                    unsetFields.push('retention');
                     update = true;
                     break;
 
                 case 'metaData':
-                    updates.$set['meta.custom'] = changes.metaData;
+                    updates['meta.custom'] = changes.metaData;
+                    update = true;
+                    break;
+
+                case 'keywords':
+                    removeNonSystemFlags = true;
+                    addFlags.push(...changes.keywords);
+                    update = true;
+                    break;
+
+                case 'addKeywords':
+                    addFlags.push(...changes.addKeywords);
+                    update = true;
+                    break;
+
+                case 'removeKeywords':
+                    removeFlags.push(...changes.removeKeywords);
                     update = true;
                     break;
             }
@@ -1612,18 +1628,31 @@ class MessageHandler {
             return callback(new Error('Nothing was changed'));
         }
 
-        if (addFlags.length) {
-            if (!updates.$addToSet) {
-                updates.$addToSet = {};
+        if (addFlags.length || removeFlags.length || removeNonSystemFlags) {
+            let base;
+            if (removeNonSystemFlags) {
+                // Strip all existing custom keywords; keep only system flags that aren't being removed
+                base = {
+                    $filter: {
+                        input: '$flags',
+                        as: 'flag',
+                        cond: removeFlags.length
+                            ? { $and: [{ $in: ['$$flag', [...consts.SYSTEM_FLAGS]] }, { $not: { $in: ['$$flag', removeFlags] } }] }
+                            : { $in: ['$$flag', [...consts.SYSTEM_FLAGS]] }
+                    }
+                };
+            } else {
+                base = removeFlags.length
+                    ? {
+                          $filter: {
+                              input: '$flags',
+                              as: 'flag',
+                              cond: { $not: { $in: ['$$flag', removeFlags] } }
+                          }
+                      }
+                    : '$flags';
             }
-            updates.$addToSet.flags = { $each: addFlags };
-        }
-
-        if (removeFlags.length) {
-            if (!updates.$pull) {
-                updates.$pull = {};
-            }
-            updates.$pull.flags = { $in: removeFlags };
+            updates.flags = { $setUnion: [base, addFlags] };
         }
 
         // acquire new MODSEQ
@@ -1652,7 +1681,13 @@ class MessageHandler {
 
                 let mailboxData = item.value;
 
-                updates.$set.modseq = mailboxData.modifyIndex;
+                updates.modseq = mailboxData.modifyIndex;
+
+                // Pipeline form so $setUnion in updates.flags can reference $flags
+                let updatePipeline = [{ $set: updates }];
+                if (unsetFields.length) {
+                    updatePipeline.push({ $unset: unsetFields });
+                }
 
                 let updatedCount = 0;
                 let cursor = this.database
@@ -1703,7 +1738,7 @@ class MessageHandler {
                                 mailbox,
                                 uid: messageData.uid
                             },
-                            updates,
+                            updatePipeline,
                             {
                                 projection: {
                                     _id: true,

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -642,6 +642,7 @@ class MessageHandler {
                             message: messageData._id,
                             modseq: messageData.modseq,
                             unseen: messageData.unseen,
+                            keywords: tools.extractKeywords(messageData.flags),
                             idate: messageData.idate,
                             thread: messageData.thread
                         },
@@ -912,6 +913,7 @@ class MessageHandler {
                         uid: messageData.uid,
                         message: messageData._id,
                         unseen: messageData.unseen,
+                        keywords: tools.extractKeywords(messageData.flags),
                         thread: messageData.thread
                     },
                     err => {
@@ -1320,6 +1322,7 @@ class MessageHandler {
                             uid: uidNext,
                             message: insertId,
                             unseen: messageData.unseen,
+                            keywords: tools.extractKeywords(messageData.flags),
                             idate: messageData.idate,
                             thread: messageData.thread
                         };
@@ -1698,7 +1701,8 @@ class MessageHandler {
                     })
                     .project({
                         _id: true,
-                        uid: true
+                        uid: true,
+                        flags: true
                     });
 
                 let done = err => {
@@ -1757,15 +1761,24 @@ class MessageHandler {
                                     return processNext();
                                 }
 
-                                let messageData = item.value;
+                                let updatedMessageData = item.value;
+
+                                const oldKeywords = new Set(tools.extractKeywords(messageData.flags));
+                                const newKeywords = new Set(tools.extractKeywords(updatedMessageData.flags));
+
+                                const addedKeywords = Array.from(newKeywords).filter(keyword => !oldKeywords.has(keyword));
+                                const removedKeywords = Array.from(oldKeywords).filter(keyword => !newKeywords.has(keyword));
+
                                 updatedCount++;
 
                                 notifyEntries.push({
                                     command: 'FETCH',
-                                    uid: messageData.uid,
-                                    flags: messageData.flags,
-                                    thread: messageData.thread,
-                                    message: messageData._id,
+                                    uid: updatedMessageData.uid,
+                                    flags: updatedMessageData.flags,
+                                    addedKeywords,
+                                    removedKeywords,
+                                    thread: updatedMessageData.thread,
+                                    message: updatedMessageData._id,
                                     unseenChange: 'seen' in changes
                                 });
 
@@ -2244,6 +2257,7 @@ class MessageHandler {
                 message: messageId,
                 thread: message.thread,
                 unseen,
+                keywords: tools.extractKeywords(message.flags),
                 // modseq is needed to avoid updating mailbox entry
                 modseq: newModseq
             });
@@ -2258,6 +2272,7 @@ class MessageHandler {
             uid: uidNext,
             message: insertId,
             unseen: message.unseen,
+            keywords: tools.extractKeywords(message.flags),
             idate: message.idate,
             thread: message.thread
         };

--- a/lib/prepare-search-filter.js
+++ b/lib/prepare-search-filter.js
@@ -116,6 +116,7 @@ const prepareSearchFilter = async (db, user, payload) => {
     const filterFlagged = payload.flagged;
     const filterUnseen = payload.unseen;
     const filterSeen = payload.seen;
+    const filterKeyword = payload.keyword;
     const filterSearchable = payload.searchable;
     const useAndSearch = payload.useAndSearch === true;
     const filterMinSize = payload.minSize;
@@ -336,6 +337,10 @@ const prepareSearchFilter = async (db, user, payload) => {
                 }
             }
         });
+    }
+
+    if (filterKeyword) {
+        filter.flags = filterKeyword;
     }
 
     if (filterAttachments) {

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -121,6 +121,12 @@ const usernameSchema = Joi.string()
     .min(1)
     .max(128);
 
+const keywordSchema = Joi.string()
+    .max(255)
+    .regex(/^[^\s"%()*[\\\]{]+$/);
+
+const keywordsSchema = Joi.array().items(keywordSchema);
+
 module.exports = {
     sessSchema,
     sessIPSchema,
@@ -131,5 +137,7 @@ module.exports = {
     booleanSchema,
     metaDataSchema,
     usernameSchema,
+    keywordSchema,
+    keywordsSchema,
     mailboxPathValidator
 };

--- a/lib/schemas/request/filters-schemas.js
+++ b/lib/schemas/request/filters-schemas.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Joi = require('joi');
-const { booleanSchema } = require('../../schemas');
+const { booleanSchema, keywordsSchema } = require('../../schemas');
 
 const FilterAction = Joi.object({
     seen: booleanSchema.allow(null).description('If true then mark matching messages as Seen (null clears action)'),
@@ -21,7 +21,10 @@ const FilterAction = Joi.object({
         .empty('')
         .description(
             'An array of forwarding targets. The value could either be an email address or a relay url to next MX server ("smtp://mx2.zone.eu:25") or an URL where mail contents are POSTed to'
-        )
+        ),
+    keywords: keywordsSchema
+        .empty('')
+        .description('An array of keywords to apply to matching messages')
 })
     .default({})
     .description('Action to take with a matching message')

--- a/lib/tasks/search-apply.js
+++ b/lib/tasks/search-apply.js
@@ -39,7 +39,7 @@ let run = async (task, data, options) => {
 
     try {
         let updates = {};
-        for (let key of ['seen', 'flagged']) {
+        for (let key of ['seen', 'flagged', 'keywords', 'addKeywords', 'removeKeywords']) {
             if (key in action) {
                 updates[key] = action[key];
             }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -243,6 +243,105 @@ function applyMessageRetention(messageData, mailboxData, addedAt = Date.now()) {
     return messageData;
 }
 
+function extractKeywords(flags) {
+    return [...new Set((flags ?? []).filter(flag => flag && !consts.SYSTEM_FLAGS.has(flag)))];
+}
+
+async function getKeywordCounter(db, user, keyword, type) {
+    const cacheKey = `kw:${type || 'total'}:${user.toString()}:${keyword}`;
+
+    try {
+        // Check cache for pre-calculated counter value
+        let sum = await db.redis.get(cacheKey);
+        if (sum !== null && !isNaN(sum) && Number(sum) >= 0) {
+            return Number(sum);
+        }
+
+        const mailboxes = await db.database
+            .collection('mailboxes')
+            .find(
+                {
+                    user
+                },
+                {
+                    projection: {
+                        _id: true
+                    }
+                }
+            )
+            .toArray();
+
+        let query = {
+            mailbox: {
+                $in: mailboxes.map(mailboxData => mailboxData._id)
+            },
+            flags: keyword
+        };
+
+        if (type) {
+            query[type] = true;
+        }
+
+        sum = await db.database.collection('messages').countDocuments(query);
+
+        // Cache calculated sum in redis
+        await db.redis.multi().set(cacheKey, sum).expire(cacheKey, consts.KEYWORD_COUNTER_TTL).exec();
+
+        return sum;
+    } catch (err) {
+        errors.notify(err);
+        throw err;
+    }
+}
+
+async function getFlaggedCounter(db, user, type) {
+    const userKey = user.toString();
+    const cacheKey = type === 'unseen' ? `fl:unseen:${userKey}` : `fl:total:${userKey}`;
+
+    try {
+        // Check cache for pre-calculated counter value
+        let sum = await db.redis.get(cacheKey);
+        if (sum !== null && !isNaN(sum) && Number(sum) >= 0) {
+            return Number(sum);
+        }
+
+        const mailboxes = await db.database
+            .collection('mailboxes')
+            .find(
+                {
+                    user
+                },
+                {
+                    projection: {
+                        _id: true
+                    }
+                }
+            )
+            .toArray();
+
+        const query = {
+            mailbox: {
+                $in: mailboxes.map(mailboxData => mailboxData._id)
+            },
+            flagged: true
+        };
+
+        if (type === 'unseen') {
+            query.unseen = true;
+        }
+
+        sum = await db.database.collection('messages').countDocuments(query);
+
+        // Cache calculated sum in redis
+        await db.redis.multi().set(cacheKey, sum).expire(cacheKey, consts.KEYWORD_COUNTER_TTL).exec();
+
+        return sum;
+    } catch (err) {
+        errors.notify(err);
+        throw err;
+    }
+}
+
 function renderEmailTemplate(tags, template) {
     let result = JSON.parse(JSON.stringify(template));
 
@@ -837,9 +936,12 @@ module.exports = {
     checkRangeQuery,
     decodeAddresses,
     flatAddresses,
+    extractKeywords,
     getMailboxCounter,
     getMessageRetentionState,
     applyMessageRetention,
+    getKeywordCounter,
+    getFlaggedCounter,
     getEmailTemplates,
     getRelayData,
     isId,

--- a/lib/user-handler.js
+++ b/lib/user-handler.js
@@ -3264,7 +3264,6 @@ class UserHandler {
             if (key === 'imapMaxConnections') {
                 flushHKeys.push({ key: 'lim:imap', value: user.toString() });
             }
-
             if (key === 'suspended' && data.suspended) {
                 // force logout after updates
                 wasSuspended = true;

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -787,6 +787,193 @@ describe('API tests', function () {
         });
     });
 
+    describe('keywords', () => {
+        let messageId;
+
+        before(async () => {
+            const response = await server
+                .post(`/users/${userId}/mailboxes/${inbox}/messages`)
+                .send({
+                    from: { name: 'Keyword Tester', address: 'kwtest@example.com' },
+                    subject: 'keyword test message',
+                    text: 'Testing keywords'
+                })
+                .expect(200);
+            expect(response.body.success).to.be.true;
+            messageId = response.body.message.id;
+        });
+
+        after(async () => {
+            if (messageId) {
+                await server.delete(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            }
+        });
+
+        it('should POST /users/:user/mailboxes/:mailbox/messages with keywords expect success / keywords appear in GET', async () => {
+            const uploadResponse = await server
+                .post(`/users/${userId}/mailboxes/${inbox}/messages`)
+                .send({
+                    from: { name: 'Keyword Tester', address: 'kwtest@example.com' },
+                    subject: 'upload with keywords',
+                    text: 'Testing upload keywords',
+                    keywords: ['important', 'project-x']
+                })
+                .expect(200);
+            expect(uploadResponse.body.success).to.be.true;
+
+            const msgId = uploadResponse.body.message.id;
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${msgId}`).expect(200);
+            expect(getResponse.body.keywords).to.have.members(['important', 'project-x']);
+
+            await server.delete(`/users/${userId}/mailboxes/${inbox}/messages/${msgId}`).expect(200);
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message set and replace keywords expect success', async () => {
+            const putResponse = await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['todo', 'urgent'] })
+                .expect(200);
+            expect(putResponse.body.success).to.be.true;
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.keywords).to.have.members(['todo', 'urgent']);
+
+            // Replacing keywords removes the old ones
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).send({ keywords: ['new-tag'] }).expect(200);
+
+            const getResponse2 = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse2.body.keywords).to.deep.equal(['new-tag']);
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message clear keywords with empty array expect success', async () => {
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['to-be-cleared'] })
+                .expect(200);
+
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).send({ keywords: [] }).expect(200);
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.keywords).to.deep.equal([]);
+        });
+
+        it('should GET /users/:user/mailboxes/:mailbox/messages keywords appear in listing expect success', async () => {
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['list-test'] })
+                .expect(200);
+
+            const listResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages`).expect(200);
+            expect(listResponse.body.success).to.be.true;
+            const found = listResponse.body.results.find(m => m.id === messageId);
+            expect(found).to.exist;
+            expect(found.keywords).to.include('list-test');
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message system flags unaffected by keyword changes expect success', async () => {
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).send({ seen: true }).expect(200);
+
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['check-flags'] })
+                .expect(200);
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.seen).to.be.true;
+            expect(getResponse.body.keywords).to.include('check-flags');
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message addKeywords expect success', async () => {
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['base'] })
+                .expect(200);
+
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ addKeywords: ['added'] })
+                .expect(200);
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.keywords).to.include.members(['base', 'added']);
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message removeKeywords expect success', async () => {
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['keep', 'remove-me'] })
+                .expect(200);
+
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ removeKeywords: ['remove-me'] })
+                .expect(200);
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.keywords).to.deep.equal(['keep']);
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message keywords with addKeywords expect failure', async () => {
+            const putResponse = await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['a'], addKeywords: ['b'] })
+                .expect(400);
+            expect(putResponse.body.error).to.exist;
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message addKeywords and removeKeywords together expect success', async () => {
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['keep', 'remove-me'] })
+                .expect(200);
+
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ addKeywords: ['added'], removeKeywords: ['remove-me'] })
+                .expect(200);
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.keywords).to.deep.equal(['keep', 'added']);
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message multiple flag changes in single request expect success', async () => {
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ seen: true, keywords: ['old'] })
+                .expect(200);
+
+            // Flip seen, add deleted, and replace keywords — all in one atomic operation
+            const putResponse = await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ seen: false, deleted: true, keywords: ['new'] })
+                .expect(200);
+            expect(putResponse.body.success).to.be.true;
+
+            const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
+            expect(getResponse.body.seen).to.be.false;
+            expect(getResponse.body.deleted).to.be.true;
+            expect(getResponse.body.keywords).to.deep.equal(['new']);
+        });
+
+        it('should PUT /users/:user/mailboxes/:mailbox/messages/:message invalid keyword expect failure', async () => {
+            const putResponse = await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`)
+                .send({ keywords: ['invalid keyword'] })
+                .expect(400);
+            expect(putResponse.body.error).to.exist;
+        });
+
+        it('should GET /users/:user/search keyword filter expect success', async () => {
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).send({ keywords: ['search-target'] }).expect(200);
+
+            const searchResponse = await server.get(`/users/${userId}/search?keyword=search-target`).expect(200);
+            expect(searchResponse.body.results.some(result => result.id === messageId)).to.be.true;
+
+            const noMatchResponse = await server.get(`/users/${userId}/search?keyword=nonexistent-keyword`).expect(200);
+            expect(noMatchResponse.body.results.some(result => result.id === messageId)).to.be.false;
+        });
+    });
+
     describe('certs', () => {
         it('should POST /certs expect success', async () => {
             const response1 = await server

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -1075,6 +1075,73 @@ describe('API tests', function () {
 
             await expectCounters(createExpectedCounters(0, 0, 0, 0));
         });
+
+        it('should GET /users/:user/flagged-counter reflect flagged and seen deltas expect success', async () => {
+            const wait = timeout => new Promise(resolvePromise => setTimeout(resolvePromise, timeout));
+
+            const readFlaggedCounter = async () => {
+                const flaggedCounterResponse = await server.get(`/users/${userId}/flagged-counter`).expect(200);
+
+                return {
+                    total: flaggedCounterResponse.body.total,
+                    unseen: flaggedCounterResponse.body.unseen
+                };
+            };
+
+            const waitForExpectedCounter = async matchesExpected => {
+                for (let attemptNumber = 0; attemptNumber < 20; attemptNumber++) {
+                    const counter = await readFlaggedCounter();
+                    if (matchesExpected(counter)) {
+                        return counter;
+                    }
+                    await wait(100);
+                }
+
+                throw new Error('Flagged counter did not reach expected values in time');
+            };
+
+            const baseline = await readFlaggedCounter();
+
+            const createExpectedCounter = (totalDelta, unseenDelta) => ({
+                total: baseline.total + totalDelta,
+                unseen: baseline.unseen + unseenDelta
+            });
+
+            const expectCounter = async expectedCounter => {
+                const observedCounter = await waitForExpectedCounter(
+                    currentCounter => currentCounter.total === expectedCounter.total && currentCounter.unseen === expectedCounter.unseen
+                );
+                expect(observedCounter.total).to.equal(expectedCounter.total);
+                expect(observedCounter.unseen).to.equal(expectedCounter.unseen);
+            };
+
+            const createResponse = await server
+                .post(`/users/${userId}/mailboxes/${inbox}/messages`)
+                .send({
+                    from: { name: 'Flagged Counter Tester', address: 'flagcounter@example.com' },
+                    subject: 'flagged counters',
+                    text: 'flagged counters',
+                    unseen: true,
+                    flagged: true
+                })
+                .expect(200);
+
+            const flaggedMessageId = createResponse.body.message.id;
+
+            await expectCounter(createExpectedCounter(1, 1));
+
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${flaggedMessageId}`).send({ seen: true }).expect(200);
+
+            await expectCounter(createExpectedCounter(1, 0));
+
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${flaggedMessageId}`).send({ flagged: false }).expect(200);
+
+            await expectCounter(createExpectedCounter(0, 0));
+
+            await server.delete(`/users/${userId}/mailboxes/${inbox}/messages/${flaggedMessageId}`).expect(200);
+
+            await expectCounter(createExpectedCounter(0, 0));
+        });
     });
 
     describe('certs', () => {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -933,7 +933,7 @@ describe('API tests', function () {
                 .expect(200);
 
             const getResponse = await server.get(`/users/${userId}/mailboxes/${inbox}/messages/${messageId}`).expect(200);
-            expect(getResponse.body.keywords).to.deep.equal(['keep', 'added']);
+            expect(getResponse.body.keywords).to.include.members(['keep', 'added']);
         });
 
         it('should PUT /users/:user/mailboxes/:mailbox/messages/:message multiple flag changes in single request expect success', async () => {
@@ -971,6 +971,109 @@ describe('API tests', function () {
 
             const noMatchResponse = await server.get(`/users/${userId}/search?keyword=nonexistent-keyword`).expect(200);
             expect(noMatchResponse.body.results.some(result => result.id === messageId)).to.be.false;
+        });
+
+        it('should GET /users/:user/keyword-counters/:keyword reflect keyword and seen deltas expect success', async () => {
+            const keywordCounterKeywordOne = `kw-counter-a-${Date.now()}`;
+            const keywordCounterKeywordTwo = `kw-counter-b-${Date.now()}`;
+
+            const wait = timeout => new Promise(resolvePromise => setTimeout(resolvePromise, timeout));
+
+            const readCounters = async () => {
+                const [keywordAResponse, keywordBResponse] = await Promise.all([
+                    server.get(`/users/${userId}/keyword-counters/${keywordCounterKeywordOne}`).expect(200),
+                    server.get(`/users/${userId}/keyword-counters/${keywordCounterKeywordTwo}`).expect(200)
+                ]);
+
+                return {
+                    keywordACounter: {
+                        keyword: keywordAResponse.body.keyword,
+                        total: keywordAResponse.body.total,
+                        unseen: keywordAResponse.body.unseen
+                    },
+                    keywordBCounter: {
+                        keyword: keywordBResponse.body.keyword,
+                        total: keywordBResponse.body.total,
+                        unseen: keywordBResponse.body.unseen
+                    }
+                };
+            };
+
+            const waitForExpectedCounters = async matchesExpected => {
+                for (let attemptNumber = 0; attemptNumber < 20; attemptNumber++) {
+                    const counters = await readCounters();
+                    if (matchesExpected(counters)) {
+                        return counters;
+                    }
+                    await wait(100);
+                }
+
+                throw new Error('Keyword counters did not reach expected values in time');
+            };
+
+            const baseline = await readCounters();
+
+            const createExpectedCounters = (keywordATotalDelta, keywordAUnseenDelta, keywordBTotalDelta, keywordBUnseenDelta) => ({
+                keywordACounter: {
+                    total: baseline.keywordACounter.total + keywordATotalDelta,
+                    unseen: baseline.keywordACounter.unseen + keywordAUnseenDelta
+                },
+                keywordBCounter: {
+                    total: baseline.keywordBCounter.total + keywordBTotalDelta,
+                    unseen: baseline.keywordBCounter.unseen + keywordBUnseenDelta
+                }
+            });
+
+            const countersMatchExpected = (currentCounters, expectedCounters) =>
+                currentCounters.keywordACounter.total === expectedCounters.keywordACounter.total &&
+                currentCounters.keywordACounter.unseen === expectedCounters.keywordACounter.unseen &&
+                currentCounters.keywordBCounter.total === expectedCounters.keywordBCounter.total &&
+                currentCounters.keywordBCounter.unseen === expectedCounters.keywordBCounter.unseen;
+
+            const expectCounters = async expectedCounters => {
+                const observedCounters = await waitForExpectedCounters(currentCounters => countersMatchExpected(currentCounters, expectedCounters));
+                expect(observedCounters.keywordACounter.total).to.equal(expectedCounters.keywordACounter.total);
+                expect(observedCounters.keywordACounter.unseen).to.equal(expectedCounters.keywordACounter.unseen);
+                expect(observedCounters.keywordBCounter.total).to.equal(expectedCounters.keywordBCounter.total);
+                expect(observedCounters.keywordBCounter.unseen).to.equal(expectedCounters.keywordBCounter.unseen);
+            };
+
+            const createResponse = await server
+                .post(`/users/${userId}/mailboxes/${inbox}/messages`)
+                .send({
+                    from: { name: 'Keyword Counter Tester', address: 'kwcounter@example.com' },
+                    subject: 'keyword counters',
+                    text: 'keyword counters',
+                    unseen: true,
+                    keywords: [keywordCounterKeywordOne]
+                })
+                .expect(200);
+
+            const counterMessageId = createResponse.body.message.id;
+
+            await expectCounters(createExpectedCounters(1, 1, 0, 0));
+
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${counterMessageId}`)
+                .send({ addKeywords: [keywordCounterKeywordTwo], seen: false })
+                .expect(200);
+
+            await expectCounters(createExpectedCounters(1, 1, 1, 1));
+
+            await server.put(`/users/${userId}/mailboxes/${inbox}/messages/${counterMessageId}`).send({ seen: true }).expect(200);
+
+            await expectCounters(createExpectedCounters(1, 0, 1, 0));
+
+            await server
+                .put(`/users/${userId}/mailboxes/${inbox}/messages/${counterMessageId}`)
+                .send({ removeKeywords: [keywordCounterKeywordOne] })
+                .expect(200);
+
+            await expectCounters(createExpectedCounters(0, 0, 1, 0));
+
+            await server.delete(`/users/${userId}/mailboxes/${inbox}/messages/${counterMessageId}`).expect(200);
+
+            await expectCounters(createExpectedCounters(0, 0, 0, 0));
         });
     });
 

--- a/test/api/filters-test.js
+++ b/test/api/filters-test.js
@@ -371,6 +371,81 @@ describe('API Filters', function () {
         });
     });
 
+    describe('Filter keywords action', function () {
+        let keywordFilterId;
+
+        it('should POST /users/{user}/filters expect success / with keywords action', async () => {
+            const response = await server
+                .post(`/users/${user}/filters`)
+                .send({
+                    name: 'keywords action create',
+                    query: {
+                        from: 'keywords-create'
+                    },
+                    action: {
+                        keywords: ['important', 'project-x']
+                    }
+                })
+                .expect(200);
+            expect(response.body.success).to.be.true;
+            keywordFilterId = response.body.id;
+
+            const filterDataResponse = await server.get(`/users/${user}/filters/${keywordFilterId}`).expect(200);
+            expect(filterDataResponse.body.success).to.be.true;
+            expect(filterDataResponse.body.action.keywords).to.deep.equal(['important', 'project-x']);
+        });
+
+        it('should PUT /users/{user}/filters/{filter} expect success / update keywords action', async () => {
+            const response = await server
+                .put(`/users/${user}/filters/${keywordFilterId}`)
+                .send({
+                    action: {
+                        keywords: ['priority', 'customer']
+                    }
+                })
+                .expect(200);
+            expect(response.body.success).to.be.true;
+
+            const filterDataResponse = await server.get(`/users/${user}/filters/${keywordFilterId}`).expect(200);
+            expect(filterDataResponse.body.success).to.be.true;
+            expect(filterDataResponse.body.action.keywords).to.deep.equal(['priority', 'customer']);
+        });
+
+        it('should PUT /users/{user}/filters/{filter} expect success / clear keywords action with empty array', async () => {
+            const response = await server
+                .put(`/users/${user}/filters/${keywordFilterId}`)
+                .send({
+                    action: {
+                        keywords: []
+                    }
+                })
+                .expect(200);
+            expect(response.body.success).to.be.true;
+
+            const filterDataResponse = await server.get(`/users/${user}/filters/${keywordFilterId}`).expect(200);
+            expect(filterDataResponse.body.success).to.be.true;
+            expect(filterDataResponse.body.action).to.not.have.property('keywords');
+        });
+
+        it('should POST /users/{user}/filters expect failure / reject invalid keyword value', async () => {
+            const response = await server
+                .post(`/users/${user}/filters`)
+                .send({
+                    name: 'keywords action invalid',
+                    query: {
+                        from: 'keywords-invalid'
+                    },
+                    action: {
+                        keywords: ['contains space']
+                    }
+                })
+                .expect(400);
+
+            expect(response.body.success).to.not.exist;
+            expect(response.body.code).to.equal('InputValidationError');
+        });
+    });
+
     describe('Filter metaData', function () {
         let metaDataFilter;
 

--- a/test/filter-actions-test.js
+++ b/test/filter-actions-test.js
@@ -1,0 +1,366 @@
+/*eslint no-unused-expressions: 0 */
+/* global before, after */
+'use strict';
+
+const crypto = require('crypto');
+const supertest = require('supertest');
+const chai = require('chai');
+const nodemailer = require('nodemailer');
+const { MongoClient } = require('mongodb');
+const config = require('@zone-eu/wild-config');
+
+const expect = chai.expect;
+chai.config.includeStack = true;
+
+const server = supertest.agent(`http://127.0.0.1:${config.api.port}`);
+
+const lmtpTransport = nodemailer.createTransport({
+    lmtp: true,
+    host: '127.0.0.1',
+    port: 2424,
+    logger: false,
+    debug: false,
+    tls: {
+        rejectUnauthorized: false
+    }
+});
+
+describe('Filter actions runtime behavior', function () {
+    this.timeout(60000); // eslint-disable-line no-invalid-this
+
+    let mongoClient;
+    let senderQueueDatabase;
+
+    before(async () => {
+        mongoClient = await MongoClient.connect(config.dbs.mongo, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true
+        });
+        senderQueueDatabase = mongoClient.db(config.dbs.sender || config.dbs.dbname);
+    });
+
+    after(async () => {
+        if (mongoClient) {
+            await mongoClient.close();
+            mongoClient = undefined;
+            senderQueueDatabase = undefined;
+        }
+    });
+
+    const wait = timeout => new Promise(resolvePromise => setTimeout(resolvePromise, timeout));
+
+    /**
+     * @param {string} usernamePrefix
+     * @returns {Promise<{userId: string, address: string}>}
+     */
+    const createUser = async usernamePrefix => {
+        const uniqueSuffix = `${Date.now()}${crypto.randomBytes(4).toString('hex')}`;
+        const username = `${usernamePrefix}${uniqueSuffix}`;
+        const userAddress = `${username}@example.com`;
+
+        const createUserResponse = await server
+            .post('/users')
+            .send({
+                username,
+                password: 'secretpass',
+                address: userAddress,
+                name: `Filter Action ${usernamePrefix}`
+            })
+            .expect(200);
+
+        expect(createUserResponse.body.success).to.be.true;
+
+        return {
+            userId: createUserResponse.body.id,
+            address: userAddress
+        };
+    };
+
+    /**
+     * @param {string} userId
+     * @returns {Promise<void>}
+     */
+    const deleteUser = async userId => {
+        const deleteResponse = await server.delete(`/users/${userId}`).expect(200);
+        expect(deleteResponse.body.success).to.be.true;
+    };
+
+    /**
+     * @param {string} userId
+     * @returns {Promise<Array<any>>}
+     */
+    const listUserMailboxes = async userId => {
+        const mailboxListResponse = await server.get(`/users/${userId}/mailboxes`).expect(200);
+        expect(mailboxListResponse.body.success).to.be.true;
+        return mailboxListResponse.body.results || [];
+    };
+
+    /**
+     * @param {string} userId
+     * @param {(mailboxData: any) => boolean} mailboxPredicate
+     * @returns {Promise<any>}
+     */
+    const findMailbox = async (userId, mailboxPredicate) => {
+        const mailboxList = await listUserMailboxes(userId);
+        const mailboxData = mailboxList.find(mailboxPredicate);
+        expect(mailboxData).to.exist;
+        return mailboxData;
+    };
+
+    /**
+     * @param {string} userId
+     * @param {string} mailboxId
+     * @returns {Promise<Array<any>>}
+     */
+    const listMailboxMessages = async (userId, mailboxId) => {
+        const messageListResponse = await server.get(`/users/${userId}/mailboxes/${mailboxId}/messages`).expect(200);
+        expect(messageListResponse.body.success).to.be.true;
+        return messageListResponse.body.results || [];
+    };
+
+    /**
+     * @param {{userId: string, mailboxId: string, subjectToken: string, attempts?: number, delayMs?: number}} waitOptions
+     * @returns {Promise<any | undefined>}
+     */
+    const waitForMessageBySubject = async waitOptions => {
+        const maxAttempts = waitOptions.attempts || 12;
+        const delayMs = waitOptions.delayMs || 500;
+
+        for (let attemptNumber = 0; attemptNumber < maxAttempts; attemptNumber++) {
+            const messageList = await listMailboxMessages(waitOptions.userId, waitOptions.mailboxId);
+            const matchingMessage = messageList.find(messageData => (messageData.subject || '').includes(waitOptions.subjectToken));
+            if (matchingMessage) {
+                return matchingMessage;
+            }
+            await wait(delayMs);
+        }
+
+        return undefined;
+    };
+
+    /**
+     * @param {{recipientAddress: string, senderAddress: string, subjectToken: string}} sendOptions
+     * @returns {Promise<void>}
+     */
+    const sendMatchingMessage = async sendOptions => {
+        const sendResult = await lmtpTransport.sendMail({
+            envelope: {
+                from: sendOptions.senderAddress,
+                to: [sendOptions.recipientAddress]
+            },
+            from: `Filter Action Sender <${sendOptions.senderAddress}>`,
+            to: `Recipient <${sendOptions.recipientAddress}>`,
+            subject: `Filter action test ${sendOptions.subjectToken}`,
+            text: `Message for filter action ${sendOptions.subjectToken}`
+        });
+
+        expect(sendResult.accepted).to.include(sendOptions.recipientAddress);
+    };
+
+    /**
+     * @param {{userId: string, queryFrom: string, action: Record<string, unknown>}} filterOptions
+     * @returns {Promise<string>}
+     */
+    const createFilter = async filterOptions => {
+        const createFilterResponse = await server
+            .post(`/users/${filterOptions.userId}/filters`)
+            .send({
+                name: `runtime filter ${filterOptions.queryFrom}`,
+                query: {
+                    from: filterOptions.queryFrom
+                },
+                action: filterOptions.action
+            })
+            .expect(200);
+
+        expect(createFilterResponse.body.success).to.be.true;
+        return createFilterResponse.body.id;
+    };
+
+    /**
+     * @param {{recipientAddress: string, attempts?: number, delayMs?: number}} waitOptions
+     * @returns {Promise<any | undefined>}
+     */
+    const waitForForwardQueueEntry = async waitOptions => {
+        const maxAttempts = waitOptions.attempts || 24;
+        const delayMs = waitOptions.delayMs || 500;
+
+        for (let attemptNumber = 0; attemptNumber < maxAttempts; attemptNumber++) {
+            const queueEntry = await senderQueueDatabase.collection('zone-queue').findOne({
+                recipient: waitOptions.recipientAddress
+            });
+
+            if (queueEntry) {
+                return queueEntry;
+            }
+
+            await wait(delayMs);
+        }
+
+        return undefined;
+    };
+
+    const actionCases = [
+        {
+            caseName: 'seen action',
+            actionBuilder: async () => ({ seen: true }),
+            verify: async context => {
+                const inboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken
+                });
+
+                expect(inboxMessage).to.exist;
+                expect(inboxMessage.seen).to.equal(true);
+            }
+        },
+        {
+            caseName: 'flag action',
+            actionBuilder: async () => ({ flag: true }),
+            verify: async context => {
+                const inboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken
+                });
+
+                expect(inboxMessage).to.exist;
+                expect(inboxMessage.flagged).to.equal(true);
+            }
+        },
+        {
+            caseName: 'spam action',
+            actionBuilder: async () => ({ spam: true }),
+            verify: async context => {
+                const junkMailbox = await findMailbox(
+                    context.mainUser.userId,
+                    mailboxData => mailboxData.specialUse === '\\Junk'
+                );
+
+                const junkMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: junkMailbox.id,
+                    subjectToken: context.subjectToken
+                });
+
+                expect(junkMessage).to.exist;
+
+                const inboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken,
+                    attempts: 3,
+                    delayMs: 300
+                });
+                expect(inboxMessage).to.equal(undefined);
+            }
+        },
+        {
+            caseName: 'mailbox action',
+            actionBuilder: async context => {
+                const createMailboxResponse = await server
+                    .post(`/users/${context.mainUser.userId}/mailboxes`)
+                    .send({
+                        path: '/RuntimeTargetMailbox',
+                        hidden: false,
+                        retention: 0
+                    })
+                    .expect(200);
+
+                expect(createMailboxResponse.body.success).to.be.true;
+
+                context.targetMailboxId = createMailboxResponse.body.id;
+                return { mailbox: context.targetMailboxId };
+            },
+            verify: async context => {
+                const targetMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.targetMailboxId,
+                    subjectToken: context.subjectToken
+                });
+
+                expect(targetMessage).to.exist;
+            }
+        },
+        {
+            caseName: 'delete action',
+            actionBuilder: async () => ({ delete: true }),
+            verify: async context => {
+                const inboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken,
+                    attempts: 5,
+                    delayMs: 300
+                });
+
+                expect(inboxMessage).to.equal(undefined);
+            }
+        },
+        {
+            caseName: 'targets action',
+            actionBuilder: async context => {
+                context.forwardTargetAddress = `queued-target-${Date.now()}${crypto.randomBytes(4).toString('hex')}@example.net`;
+                return { targets: [context.forwardTargetAddress] };
+            },
+            verify: async context => {
+                const originInboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken
+                });
+                expect(originInboxMessage).to.exist;
+
+                const forwardQueueEntry = await waitForForwardQueueEntry({
+                    recipientAddress: context.forwardTargetAddress,
+                    attempts: 24,
+                    delayMs: 500
+                });
+                expect(forwardQueueEntry).to.exist;
+            }
+        }
+    ];
+
+    for (const actionCase of actionCases) {
+        it(`should apply ${actionCase.caseName} on inbound message`, async () => {
+            const context = {
+                createdUsers: []
+            };
+
+            try {
+                context.mainUser = await createUser('runtimeaction');
+                context.createdUsers.push(context.mainUser.userId);
+                context.inboxMailbox = await findMailbox(context.mainUser.userId, mailboxData => mailboxData.path === 'INBOX');
+
+                context.senderTag = `runtime-${actionCase.caseName.replace(/\s+/g, '-')}-${Date.now()}${crypto.randomBytes(2).toString('hex')}`;
+                context.senderAddress = `${context.senderTag}@example.com`;
+                context.subjectToken = `${actionCase.caseName}-${Date.now()}${crypto.randomBytes(2).toString('hex')}`;
+
+                const action = await actionCase.actionBuilder(context);
+                await createFilter({
+                    userId: context.mainUser.userId,
+                    queryFrom: context.senderTag,
+                    action
+                });
+
+                await sendMatchingMessage({
+                    recipientAddress: context.mainUser.address,
+                    senderAddress: context.senderAddress,
+                    subjectToken: context.subjectToken
+                });
+
+                await actionCase.verify(context);
+            } finally {
+                while (context.createdUsers.length) {
+                    const userId = context.createdUsers.pop();
+                    if (!userId) {
+                        continue;
+                    }
+
+                    await deleteUser(userId);
+                }
+            }
+        });
+    }
+});

--- a/test/filter-actions-test.js
+++ b/test/filter-actions-test.js
@@ -230,13 +230,24 @@ describe('Filter actions runtime behavior', function () {
             }
         },
         {
+            caseName: 'keywords action',
+            actionBuilder: async () => ({ keywords: ['runtime-keyword'] }),
+            verify: async context => {
+                const inboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken
+                });
+
+                expect(inboxMessage).to.exist;
+                expect(inboxMessage.keywords).to.include('runtime-keyword');
+            }
+        },
+        {
             caseName: 'spam action',
             actionBuilder: async () => ({ spam: true }),
             verify: async context => {
-                const junkMailbox = await findMailbox(
-                    context.mainUser.userId,
-                    mailboxData => mailboxData.specialUse === '\\Junk'
-                );
+                const junkMailbox = await findMailbox(context.mainUser.userId, mailboxData => mailboxData.specialUse === '\\Junk');
 
                 const junkMessage = await waitForMessageBySubject({
                     userId: context.mainUser.userId,
@@ -319,6 +330,37 @@ describe('Filter actions runtime behavior', function () {
                 });
                 expect(forwardQueueEntry).to.exist;
             }
+        },
+        {
+            caseName: 'combined action in one filter',
+            actionBuilder: async context => {
+                context.forwardTargetAddress = `queued-combined-${Date.now()}${crypto.randomBytes(4).toString('hex')}@example.net`;
+                return {
+                    seen: true,
+                    flag: true,
+                    keywords: ['combined-a', 'combined-b'],
+                    targets: [context.forwardTargetAddress]
+                };
+            },
+            verify: async context => {
+                const inboxMessage = await waitForMessageBySubject({
+                    userId: context.mainUser.userId,
+                    mailboxId: context.inboxMailbox.id,
+                    subjectToken: context.subjectToken
+                });
+
+                expect(inboxMessage).to.exist;
+                expect(inboxMessage.seen).to.equal(true);
+                expect(inboxMessage.flagged).to.equal(true);
+                expect(inboxMessage.keywords).to.include.members(['combined-a', 'combined-b']);
+
+                const forwardQueueEntry = await waitForForwardQueueEntry({
+                    recipientAddress: context.forwardTargetAddress,
+                    attempts: 24,
+                    delayMs: 500
+                });
+                expect(forwardQueueEntry).to.exist;
+            }
         }
     ];
 
@@ -363,4 +405,82 @@ describe('Filter actions runtime behavior', function () {
             }
         });
     }
+
+    it('should combine actions from multiple matching filters', async () => {
+        const context = {
+            createdUsers: []
+        };
+
+        try {
+            context.mainUser = await createUser('runtimeaction');
+            context.createdUsers.push(context.mainUser.userId);
+            context.inboxMailbox = await findMailbox(context.mainUser.userId, mailboxData => mailboxData.path === 'INBOX');
+
+            context.senderTag = `runtime-multi-filters-${Date.now()}${crypto.randomBytes(2).toString('hex')}`;
+            context.senderAddress = `${context.senderTag}@example.com`;
+            context.subjectToken = `multiple-filters-${Date.now()}${crypto.randomBytes(2).toString('hex')}`;
+            context.forwardTargetAddressOne = `queued-multi-one-${Date.now()}${crypto.randomBytes(4).toString('hex')}@example.net`;
+            context.forwardTargetAddressTwo = `queued-multi-two-${Date.now()}${crypto.randomBytes(4).toString('hex')}@example.net`;
+
+            await createFilter({
+                userId: context.mainUser.userId,
+                queryFrom: context.senderTag,
+                action: {
+                    seen: true,
+                    keywords: ['multi-one'],
+                    targets: [context.forwardTargetAddressOne]
+                }
+            });
+
+            await createFilter({
+                userId: context.mainUser.userId,
+                queryFrom: context.senderTag,
+                action: {
+                    flag: true,
+                    keywords: ['multi-two'],
+                    targets: [context.forwardTargetAddressTwo]
+                }
+            });
+
+            await sendMatchingMessage({
+                recipientAddress: context.mainUser.address,
+                senderAddress: context.senderAddress,
+                subjectToken: context.subjectToken
+            });
+
+            const inboxMessage = await waitForMessageBySubject({
+                userId: context.mainUser.userId,
+                mailboxId: context.inboxMailbox.id,
+                subjectToken: context.subjectToken
+            });
+
+            expect(inboxMessage).to.exist;
+            expect(inboxMessage.seen).to.equal(true);
+            expect(inboxMessage.flagged).to.equal(true);
+            expect(inboxMessage.keywords).to.include.members(['multi-one', 'multi-two']);
+
+            const forwardQueueEntryOne = await waitForForwardQueueEntry({
+                recipientAddress: context.forwardTargetAddressOne,
+                attempts: 24,
+                delayMs: 500
+            });
+            expect(forwardQueueEntryOne).to.exist;
+
+            const forwardQueueEntryTwo = await waitForForwardQueueEntry({
+                recipientAddress: context.forwardTargetAddressTwo,
+                attempts: 24,
+                delayMs: 500
+            });
+            expect(forwardQueueEntryTwo).to.exist;
+        } finally {
+            while (context.createdUsers.length) {
+                const userId = context.createdUsers.pop();
+                if (!userId) {
+                    continue;
+                }
+
+                await deleteUser(userId);
+            }
+        }
+    });
 });


### PR DESCRIPTION
This has been a long time coming, finally found the motivation recently :)

This PR adds support for custom keywords (which are just flags). You can use these to represent labels in a webmail (#763), and sync those same labels with for example Thunderbird over IMAP.

Overview:
- Added keywords array to message CRUD
- Added endpoint to compute counters for a keyword, using redis and deltas in the same manner as mailbox counters
- Once that endpoint has been called and the value is in redis, keyword counters will be emitted over sse (`KEYWORD_COUNTERS`) for that keyword. Implemented it this way to avoid computing counters for irrelevant keywords IMAP clients might add
- Keywords also added to sse events related to message creates/updates. `keywords` on `EXISTS`, and `addedKeywords` and `removedKeywords` on `FETCH`
- Added seperate endpoint to compute counters for flagged messages. Given \flagged is a system flag it shouldn't be part of custom keywords, but knowing the total/unread for flagged messages is still very helpful
- Also added SSE for that (`FLAGGED_COUNTER`)
- No changes to IMAP or indexes, this was already fully supported


Some things:
- The current flag update code didn't allow for both deleting and adding flags in the same call, it would for example error if you set/unset both seen and deleted in the same api call. This is a MongoDB limitation, you can't use `$addToSet` and `$pull` in the same query. I switched it over to a simple aggregation pipeline that does allow for this.
- Setting draft set `flagged` in the db for some reason? Assuming that's wrong and fixed
- There were no tests for filter actions, so while I was there I added tests for all existing actions as well

I normally only work on modern TS codebases, so JS plus the old callback style isn't too familiar for me. Let me know if you see any obvious mistakes :)