### PR TITLE
ZMS-86: Message listing non-collapsed list return correct hasDrafts

### DIFF
--- a/indexes.yaml
+++ b/indexes.yaml
@@ -299,6 +299,21 @@ indexes:
 
     - collection: messages
       index:
+          # covers the collapseThreads listing and count aggregations. The trailing
+          # thread key makes the id-only grouping a covered query, uid is included
+          # so that on sharded clusters the SHARDING_FILTER stage can run off index
+          # entries instead of forcing a fetch of every document. Supersedes
+          # by_idate_reverse_uid, which shares this prefix and can be dropped
+          name: by_idate_reverse_thread
+          key:
+              mailbox: 1
+              idate: -1
+              _id: -1
+              thread: 1
+              uid: 1
+
+    - collection: messages
+      index:
           name: by_hdate
           key:
               mailbox: 1
@@ -442,6 +457,14 @@ indexes:
           key:
               user: 1
               _id: -1
+
+    - collection: archived
+      index:
+          # backs the threadCounters lookup on archived message listings
+          name: user_messages_by_thread
+          key:
+              user: 1
+              thread: 1
 
     - collection: archived
       index:

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -183,6 +183,31 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             sort._id = sortDirection;
         }
 
+        // Only carry the identifiers of each thread's newest message through the
+        // aggregation. On a sharded cluster everything after the per-shard sort runs
+        // on a single merging node, so grouping full documents with $$ROOT would move
+        // the entire mailbox over the network and spill to disk there. The page of
+        // matching documents is fetched separately by _id in getCollapsedListing()
+        const group = {
+            _id: '$thread',
+            mid: {
+                $first: '$_id'
+            }
+        };
+
+        // expose the same field names the paging cursor logic reads from a message
+        // document, with _id being the id of the message, not the thread
+        const tupleProjection = {
+            _id: '$mid'
+        };
+
+        if (paginatedField !== '_id') {
+            group[paginatedField] = {
+                $first: `$${paginatedField}`
+            };
+            tupleProjection[paginatedField] = true;
+        }
+
         return [
             {
                 $match: filter
@@ -191,19 +216,50 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 $sort: sort
             },
             {
-                $group: {
-                    _id: '$thread',
-                    message: {
-                        $first: '$$ROOT'
-                    }
-                }
+                $group: group
             },
             {
-                $replaceRoot: {
-                    newRoot: '$message'
-                }
+                $project: tupleProjection
             }
         ];
+    };
+
+    const getCollapsedListing = async (filter, { limit, projection, paginatedField, sortAscending, next, previous, maxTimeMS }) => {
+        const listingWrapper = await mongopagingAggregateWrapper(db.database.collection('messages'), {
+            pipeline: getCollapsedMessagePipeline(filter, sortAscending, paginatedField),
+            limit,
+            paginatedField,
+            sortAscending,
+            next,
+            previous,
+            aggregateOptions: {
+                allowDiskUse: true,
+                maxTimeMS
+            }
+        });
+
+        const tuples = listingWrapper.listing.results || [];
+        if (tuples.length) {
+            const documentQuery = { _id: { $in: tuples.map(tuple => tuple._id) } };
+
+            // keep equality keys from the original filter so the query stays routed
+            // to the shards that hold this mailbox instead of hitting every shard
+            for (const routingKey of ['mailbox', 'user']) {
+                if (filter[routingKey] && typeof filter[routingKey].toHexString === 'function') {
+                    documentQuery[routingKey] = filter[routingKey];
+                }
+            }
+
+            const documents = await db.database
+                .collection('messages')
+                .find(documentQuery, { projection, maxTimeMS })
+                .toArray();
+
+            const documentMap = new Map(documents.map(messageData => [messageData._id.toString(), messageData]));
+            listingWrapper.listing.results = tuples.map(tuple => documentMap.get(tuple._id.toString())).filter(messageData => messageData);
+        }
+
+        return listingWrapper;
     };
 
     const applyBimiToListing = async messages => {
@@ -669,18 +725,14 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let listingWrapper;
             try {
                 listingWrapper = collapseThreads
-                    ? await mongopagingAggregateWrapper(db.database.collection('messages'), {
-                          pipeline: getCollapsedMessagePipeline(filter, sortAscending),
+                    ? await getCollapsedListing(filter, {
                           limit,
                           projection,
                           paginatedField: 'idate',
                           sortAscending,
                           next: pageNext,
                           previous: pagePrevious,
-                          aggregateOptions: {
-                              allowDiskUse: true,
-                              maxTimeMS: consts.DB_MAX_TIME_MESSAGES
-                          }
+                          maxTimeMS: consts.DB_MAX_TIME_MESSAGES
                       })
                     : await mongopagingFindWrapper(db.database.collection('messages'), opts);
             } catch (err) {
@@ -999,18 +1051,14 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     return mongopagingFindWrapper(db.database.collection('messages'), opts);
                 }
 
-                return mongopagingAggregateWrapper(db.database.collection('messages'), {
-                    pipeline: getCollapsedMessagePipeline(filter, sortAscending, paginatedField),
+                return getCollapsedListing(filter, {
                     limit,
                     projection: opts.fields.projection,
                     paginatedField,
                     sortAscending,
                     next: pageNext,
                     previous: pagePrevious,
-                    aggregateOptions: {
-                        allowDiskUse: true,
-                        maxTimeMS
-                    }
+                    maxTimeMS
                 });
             };
 

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -109,8 +109,38 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
         return projection;
     };
 
-    const addThreadCountersToMessageList = async (user, list, collection = 'messages') => {
+    const addThreadCountersToMessageList = async (
+        user,
+        list,
+        { collection = 'messages', includeThreadMessageCount = true, includeHasDrafts = false, matchDraftReferences = false } = {}
+    ) => {
         const threadIdsToCount = list.map(message => message.thread);
+        const group = {
+            _id: '$thread'
+        };
+
+        if (includeThreadMessageCount) {
+            group.count = {
+                $sum: 1
+            };
+        }
+
+        if (includeHasDrafts && !matchDraftReferences) {
+            group.hasDrafts = {
+                $max: {
+                    $cond: ['$draft', 1, 0]
+                }
+            };
+        }
+
+        if (includeHasDrafts && matchDraftReferences) {
+            group.draftReferences = {
+                $addToSet: {
+                    $cond: ['$draft', '$mimeTree.parsedHeader.references', false]
+                }
+            };
+        }
+
         const threadCounts = await db.database
             .collection(collection)
             .aggregate([
@@ -121,17 +151,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     }
                 },
                 {
-                    $group: {
-                        _id: '$thread',
-                        count: {
-                            $sum: 1
-                        },
-                        hasDrafts: {
-                            $max: {
-                                $cond: ['$draft', 1, 0]
-                            }
-                        }
-                    }
+                    $group: group
                 }
             ])
             .toArray();
@@ -140,8 +160,27 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
         return list.map(message => {
             const matchingThreadCount = threadCountMap.get(message.thread.toString());
-            message.threadMessageCount = matchingThreadCount ? matchingThreadCount.count : undefined;
-            message.hasDrafts = !!(matchingThreadCount && matchingThreadCount.hasDrafts);
+
+            if (includeThreadMessageCount) {
+                message.threadMessageCount = matchingThreadCount ? matchingThreadCount.count : undefined;
+            }
+
+            if (!includeHasDrafts) {
+                return message;
+            }
+
+            if (matchDraftReferences) {
+                const draftReferences = new Set(
+                    ((matchingThreadCount && matchingThreadCount.draftReferences) || [])
+                        .flatMap(references => (references || '').toString().split(/\s+/))
+                        .filter(reference => reference)
+                );
+
+                message.hasDrafts = draftReferences.has(message.msgid);
+            } else {
+                message.hasDrafts = !!(matchingThreadCount && matchingThreadCount.hasDrafts);
+            }
+
             return message;
         });
     };
@@ -444,7 +483,10 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     metaData: booleanSchema.default(false).description('If true, then includes metaData in the response'),
                     threadCounters: booleanSchema
                         .default(false)
-                        .description('If true, then includes threadMessageCount and hasDrafts in the response. Counters come with some overhead'),
+                        .description('If true, then includes threadMessageCount in the response. Counters come with some overhead'),
+                    includeHasDrafts: booleanSchema
+                        .default(false)
+                        .description('If true, then calculates and includes hasDrafts in the response. This comes with some overhead'),
                     collapseThreads: booleanSchema
                         .default(false)
                         .description('If true, then returns only the newest or oldest message from each thread, depending on the order argument'),
@@ -486,7 +528,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                             'Amount of messages in the Thread. Included if threadCounters query argument was true'
                                         ),
                                         hasDrafts: booleanSchema.description(
-                                            'If true, then the Thread contains at least one draft. Included if threadCounters query argument was true'
+                                            'For collapsed results, true if the Thread contains at least one draft. For non-collapsed results, true if at least one draft references the message. Included if includeHasDrafts query argument was true'
                                         ),
                                         from: Address.description('Sender in From: field'),
                                         to: Joi.array().items(Address).required().description('Recipients in To: field'),
@@ -596,6 +638,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let mailbox = new ObjectId(result.value.mailbox);
             let limit = result.value.limit;
             let threadCounters = result.value.threadCounters;
+            let includeHasDrafts = result.value.includeHasDrafts;
             let collapseThreads = result.value.collapseThreads;
             let pageNext = result.value.next;
             let pagePrevious = result.value.previous;
@@ -691,8 +734,12 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 });
             }
 
-            if (threadCounters) {
-                listingWrapper.listing.results = await addThreadCountersToMessageList(user, listingWrapper.listing.results);
+            if (threadCounters || includeHasDrafts) {
+                listingWrapper.listing.results = await addThreadCountersToMessageList(user, listingWrapper.listing.results, {
+                    includeThreadMessageCount: threadCounters,
+                    includeHasDrafts,
+                    matchDraftReferences: !collapseThreads
+                });
             }
 
             await applyBimiToListing(listingWrapper.listing.results);
@@ -772,7 +819,10 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     ...{
                         threadCounters: booleanSchema
                             .default(false)
-                            .description('If true, then includes threadMessageCount and hasDrafts in the response. Counters come with some overhead'),
+                            .description('If true, then includes threadMessageCount in the response. Counters come with some overhead'),
+                        includeHasDrafts: booleanSchema
+                            .default(false)
+                            .description('If true, then calculates and includes hasDrafts in the response. This comes with some overhead'),
                         collapseThreads: booleanSchema
                             .default(false)
                             .description('If true, then returns only the newest or oldest matching message from each thread, depending on the order argument'),
@@ -815,7 +865,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                             'Amount of messages in the Thread. Included if threadCounters query argument was true'
                                         ),
                                         hasDrafts: booleanSchema.description(
-                                            'If true, then the Thread contains at least one draft. Included if threadCounters query argument was true'
+                                            'For collapsed results, true if the Thread contains at least one draft. For non-collapsed results, true if at least one draft references the message. Included if includeHasDrafts query argument was true'
                                         ),
                                         from: Address,
                                         to: Joi.array().items(Address).required().description('Recipients in To: field'),
@@ -921,6 +971,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
             let user = new ObjectId(result.value.user);
             let threadCounters = result.value.threadCounters;
+            let includeHasDrafts = result.value.includeHasDrafts;
             let collapseThreads = result.value.collapseThreads;
             let limit = result.value.limit;
             let pageNext = result.value.next;
@@ -1066,8 +1117,12 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 }
             }
 
-            if (threadCounters) {
-                listingWrapper.listing.results = await addThreadCountersToMessageList(user, listingWrapper.listing.results);
+            if (threadCounters || includeHasDrafts) {
+                listingWrapper.listing.results = await addThreadCountersToMessageList(user, listingWrapper.listing.results, {
+                    includeThreadMessageCount: threadCounters,
+                    includeHasDrafts,
+                    matchDraftReferences: !collapseThreads
+                });
             }
 
             await applyBimiToListing(listingWrapper.listing.results);
@@ -3525,7 +3580,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     order: Joi.any().empty('').allow('asc', 'desc').default('desc').description('Ordering of the records by insert date'),
                     threadCounters: booleanSchema
                         .default(false)
-                        .description('If true, then includes threadMessageCount and hasDrafts in the response. Counters come with some overhead'),
+                        .description('If true, then includes threadMessageCount in the response. Counters come with some overhead'),
                     includeHeaders: booleanSchema
                         .default(false)
                         .description(
@@ -3558,9 +3613,6 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                                         thread: Joi.string().required().description('ID of the Thread'),
                                         threadMessageCount: Joi.number().description(
                                             'Amount of messages in the Thread. Included if threadCounters query argument was true'
-                                        ),
-                                        hasDrafts: booleanSchema.description(
-                                            'If true, then the Thread contains at least one draft. Included if threadCounters query argument was true'
                                         ),
                                         from: Address.description('Sender in From: field'),
                                         to: Joi.array().items(Address).required().description('Recipients in To: field'),
@@ -3711,7 +3763,9 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             }
 
             if (threadCounters) {
-                listingWrapper.listing.results = await addThreadCountersToMessageList(user, listingWrapper.listing.results, 'archived');
+                listingWrapper.listing.results = await addThreadCountersToMessageList(user, listingWrapper.listing.results, {
+                    collection: 'archived'
+                });
             }
 
             await applyBimiToListing(listingWrapper.listing.results);

--- a/test/api/messages-test.js
+++ b/test/api/messages-test.js
@@ -923,7 +923,7 @@ describe('Messages tests', function () {
         expect(search5.body.results).to.deep.eq(search.body.results); // Check if page 1 is equal to original page 1 after moving back from page 2
     });
 
-    it('should GET /users/:user/search expect success / collapseThreads returns one message per thread and hasDrafts covers the entire thread', async () => {
+    it('should GET /users/:user/search expect success / collapseThreads controls the hasDrafts scope', async () => {
         const mailboxResponse = await server
             .post(`/users/${user}/mailboxes`)
             .send({ path: `/search-collapse-threads-${Date.now().toString(36)}`, hidden: false, retention: 10000 })
@@ -933,19 +933,19 @@ describe('Messages tests', function () {
         const root = await server
             .post(`/users/${user}/mailboxes/${mailbox}/messages`)
             .send({
-                draft: true,
+                draft: false,
                 to: [{ address: 'search-collapse@example.com' }],
                 subject: 'Search Collapse Thread A',
-                text: 'Draft root'
+                text: 'Root message'
             })
             .expect(200);
 
         const reply = await server
             .post(`/users/${user}/mailboxes/${mailbox}/messages`)
             .send({
-                draft: false,
+                draft: true,
                 to: [{ address: 'search-collapse@example.com' }],
-                text: 'Non-draft reply',
+                text: 'Draft reply',
                 reference: {
                     mailbox,
                     id: root.body.message.id,
@@ -953,8 +953,6 @@ describe('Messages tests', function () {
                 }
             })
             .expect(200);
-
-        await server.put(`/users/${user}/mailboxes/${mailbox}/messages/${reply.body.message.id}`).send({ draft: false }).expect(200);
 
         const single = await server
             .post(`/users/${user}/mailboxes/${mailbox}/messages`)
@@ -978,26 +976,32 @@ describe('Messages tests', function () {
         expect(expandedPage.body.total).to.equal(2);
         expect(expandedPage.body.results.map(entry => entry.id)).to.deep.equal([reply.body.message.id]);
         expect(expandedPage.body.results[0].threadMessageCount).to.equal(2);
-        expect(expandedPage.body.results[0].hasDrafts).to.be.true;
+        expect(expandedPage.body.results[0]).to.not.have.property('hasDrafts');
 
         const expandedThread = await server
-            .get(`/users/${user}/search?thread=${thread}&threadCounters=true&limit=2`)
+            .get(`/users/${user}/search?thread=${thread}&includeHasDrafts=true&limit=2`)
             .send({})
             .expect(200);
 
         expect(expandedThread.body.results.map(entry => entry.id)).to.deep.equal([reply.body.message.id, root.body.message.id]);
-        expect(expandedThread.body.results.every(entry => entry.hasDrafts)).to.be.true;
+        expect(expandedThread.body.results.map(entry => entry.hasDrafts)).to.deep.equal([false, true]);
+        expect(expandedThread.body.results[0]).to.not.have.property('threadMessageCount');
 
         const expandedMailboxPage = await server
-            .get(`/users/${user}/mailboxes/${mailbox}/messages?threadCounters=true&limit=2&order=desc`)
+            .get(`/users/${user}/mailboxes/${mailbox}/messages?includeHasDrafts=true&limit=3&order=desc`)
             .send({})
             .expect(200);
 
-        expect(expandedMailboxPage.body.results.map(entry => entry.id)).to.deep.equal([single.body.message.id, reply.body.message.id]);
-        expect(expandedMailboxPage.body.results.map(entry => entry.hasDrafts)).to.deep.equal([false, true]);
+        expect(expandedMailboxPage.body.results.map(entry => entry.id)).to.deep.equal([
+            single.body.message.id,
+            reply.body.message.id,
+            root.body.message.id
+        ]);
+        expect(expandedMailboxPage.body.results.map(entry => entry.hasDrafts)).to.deep.equal([false, false, true]);
+        expect(expandedMailboxPage.body.results[0]).to.not.have.property('threadMessageCount');
 
         const collapsedPage1 = await server
-            .get(`/users/${user}/search?mailbox=${mailbox}&collapseThreads=true&threadCounters=true&limit=1`)
+            .get(`/users/${user}/search?mailbox=${mailbox}&collapseThreads=true&threadCounters=true&includeHasDrafts=true&limit=1`)
             .send({})
             .expect(200);
 
@@ -1017,7 +1021,7 @@ describe('Messages tests', function () {
 
         const collapsedPage2 = await server
             .get(
-                `/users/${user}/search?mailbox=${mailbox}&collapseThreads=true&threadCounters=true&limit=1&next=${encodeURIComponent(
+                `/users/${user}/search?mailbox=${mailbox}&collapseThreads=true&threadCounters=true&includeHasDrafts=true&limit=1&next=${encodeURIComponent(
                     collapsedPage1.body.nextCursor
                 )}`
             )
@@ -1029,6 +1033,14 @@ describe('Messages tests', function () {
         expect(collapsedPage2.body.results[0].hasDrafts).to.be.true;
         expect(collapsedPage2.body.previousCursor).to.be.a('string');
         expect(collapsedPage2.body.nextCursor).to.be.false;
+
+        await server.delete(`/users/${user}/mailboxes/${mailbox}/messages/${root.body.message.id}`).send({}).expect(200);
+
+        const archived = await server.get(`/users/${user}/archived/messages?threadCounters=true&limit=250`).send({}).expect(200);
+        const archivedRoot = archived.body.results.find(entry => entry.thread === thread);
+
+        expect(archivedRoot).to.exist;
+        expect(archivedRoot).to.not.have.property('hasDrafts');
     });
 
     it('should GET /users/:user/search expect success / q supports subject and in keywords', async () => {
@@ -1777,7 +1789,7 @@ describe('Messages tests', function () {
             .post(`/users/${user}/mailboxes/${collapseMailbox}/messages`)
             .send({
                 date: new Date('2026-01-01T00:00:00.000Z'),
-                draft: true,
+                draft: false,
                 to: [{ address: 'collapse.thread@example.com' }],
                 subject: 'Collapse Thread A',
                 text: 'Root message'
@@ -1825,8 +1837,23 @@ describe('Messages tests', function () {
             })
             .expect(200);
 
+        const expanded = await server
+            .get(`/users/${user}/mailboxes/${collapseMailbox}/messages?includeHasDrafts=true&limit=10&order=asc`)
+            .send({})
+            .expect(200);
+
+        expect(expanded.body.results.map(entry => entry.id)).to.deep.equal([
+            threadRoot.body.message.id,
+            singleB.body.message.id,
+            threadReply.body.message.id,
+            singleC.body.message.id
+        ]);
+        expect(expanded.body.results.map(entry => entry.hasDrafts)).to.deep.equal([true, false, false, false]);
+
         const descPage1 = await server
-            .get(`/users/${user}/mailboxes/${collapseMailbox}/messages?collapseThreads=true&threadCounters=true&limit=2&order=desc`)
+            .get(
+                `/users/${user}/mailboxes/${collapseMailbox}/messages?collapseThreads=true&threadCounters=true&includeHasDrafts=true&limit=2&order=desc`
+            )
             .send({})
             .expect(200);
 
@@ -1887,7 +1914,7 @@ describe('Messages tests', function () {
 
         const descPage2 = await server
             .get(
-                `/users/${user}/mailboxes/${collapseMailbox}/messages?collapseThreads=true&threadCounters=true&limit=2&order=desc&next=${encodeURIComponent(
+                `/users/${user}/mailboxes/${collapseMailbox}/messages?collapseThreads=true&threadCounters=true&includeHasDrafts=true&limit=2&order=desc&next=${encodeURIComponent(
                     descPage1.body.nextCursor
                 )}`
             )
@@ -1903,7 +1930,7 @@ describe('Messages tests', function () {
 
         const descPage1Again = await server
             .get(
-                `/users/${user}/mailboxes/${collapseMailbox}/messages?collapseThreads=true&threadCounters=true&limit=2&order=desc&previous=${encodeURIComponent(
+                `/users/${user}/mailboxes/${collapseMailbox}/messages?collapseThreads=true&threadCounters=true&includeHasDrafts=true&limit=2&order=desc&previous=${encodeURIComponent(
                     descPage2.body.previousCursor
                 )}`
             )
@@ -1978,6 +2005,7 @@ describe('Messages tests', function () {
         expect(singleThread.body.total).to.equal(1);
         expect(singleThread.body.results.map(entry => entry.id)).to.deep.equal([reply.body.message.id]);
         expect(singleThread.body.results[0].threadMessageCount).to.equal(2);
+        expect(singleThread.body.results[0]).to.not.have.property('hasDrafts');
         expect(singleThread.body.nextCursor).to.be.false;
         expect(singleThread.body.previousCursor).to.be.false;
     });

--- a/test/api/webauthn-test.js
+++ b/test/api/webauthn-test.js
@@ -130,7 +130,7 @@ function base64UrlDecode(value) {
     return Buffer.from(input, 'base64');
 }
 
-describe.only('API WebAuthn', function () {
+describe('API WebAuthn', function () {
     this.timeout(10000); // eslint-disable-line no-invalid-this
 
     const password = 'webauthnsecretvalue';


### PR DESCRIPTION
When requesting the classic message listing of a mailbox (threads not collapsed), show the hasDrafts boolean only for the message that is actually referenced by the draft that it has instead of displaying hasDrafts: true for all messages in the same thread.