### PR TITLE
fix(audit): reject store() when the GridFS upload stream errors

### DIFF
--- a/lib/audit-handler.js
+++ b/lib/audit-handler.js
@@ -154,6 +154,7 @@ class AuditHandler {
                 metadata
             });
 
+            stream.on('error', err => reject(err));
             stream.once('finish', () => resolve(id));
 
             if (Buffer.isBuffer(message)) {


### PR DESCRIPTION
`AuditHandler.store()` wires up only `finish` on the GridFS upload stream (line 157), so a failed upload emits `error` with nobody listening, the process exits with code 1, and the promise never settles.

I reproduced it against a real mongod: a 256 MB message, server killed right after the fifth insert was acknowledged, triggered from the driver's command monitoring rather than a timer so the write is still in flight. Same with 4 MB killed after the first insert. With the listener added `store()` rejects in around 290 ms, and a healthy mongod is unaffected either way, about a second for the 1030 inserts a full run makes. Environment: node 24.18.1, mongodb 4.17.2 as pinned, standalone mongod 8.2.6, killed outright so no retryable write could succeed. This is the array path through `writeChunks()`, where `lib/message-handler.js` and `lib/filter-handler.js` end up. I didn't exercise the `pipe` branch that `lib/tasks/audit.js` uses.

The unsettled promise matters too. `lib/message-handler.js` awaits `auditPromises` on line 727 and resolves the enclosing add only on 744 and 745, so with an active audit for the user that promise never resolves.

The three other upload streams each attach an error listener (`lib/attachments/gridstore-storage.js:268`, `lib/maildropper.js:526`, `lib/storage-handler.js:142`). I put mine before `finish` and used `on` to match the last one, which has the same `new Promise((resolve, reject))` shape.

Two gaps it leaves. Chunks written before the failure stay in `audit.chunks` with no `audit.files` document, and `removeAudit` and `cleanExpired` both iterate `audit.files`, so nothing collects them; that holds today too, since the crash orphans the same chunks. And the rejection lands in the `.catch` on line 745, which resolves without logging, so where an operator sees a crash today they would see nothing. I didn't want to guess how you'd want either handled.

Happy to add a test, though it needs mongod to fail mid upload, which doesn't fit the current suite. I can share the script I used.
