### PR TITLE
perf(api): avoid moving full documents through the collapseThreads aggregation

### DIFF
--- a/indexes.yaml
+++ b/indexes.yaml
@@ -299,6 +299,21 @@ indexes:
 
     - collection: messages
       index:
+          # covers the collapseThreads listing and count aggregations. The trailing
+          # thread key makes the id-only grouping a covered query, uid is included
+          # so that on sharded clusters the SHARDING_FILTER stage can run off index
+          # entries instead of forcing a fetch of every document. Supersedes
+          # by_idate_reverse_uid, which shares this prefix and can be dropped
+          name: by_idate_reverse_thread
+          key:
+              mailbox: 1
+              idate: -1
+              _id: -1
+              thread: 1
+              uid: 1
+
+    - collection: messages
+      index:
           name: by_hdate
           key:
               mailbox: 1
@@ -442,6 +457,14 @@ indexes:
           key:
               user: 1
               _id: -1
+
+    - collection: archived
+      index:
+          # backs the threadCounters lookup on archived message listings
+          name: user_messages_by_thread
+          key:
+              user: 1
+              thread: 1
 
     - collection: archived
       index:

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -183,6 +183,31 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             sort._id = sortDirection;
         }
 
+        // Only carry the identifiers of each thread's newest message through the
+        // aggregation. On a sharded cluster everything after the per-shard sort runs
+        // on a single merging node, so grouping full documents with $$ROOT would move
+        // the entire mailbox over the network and spill to disk there. The page of
+        // matching documents is fetched separately by _id in getCollapsedListing()
+        const group = {
+            _id: '$thread',
+            mid: {
+                $first: '$_id'
+            }
+        };
+
+        // expose the same field names the paging cursor logic reads from a message
+        // document, with _id being the id of the message, not the thread
+        const tupleProjection = {
+            _id: '$mid'
+        };
+
+        if (paginatedField !== '_id') {
+            group[paginatedField] = {
+                $first: `$${paginatedField}`
+            };
+            tupleProjection[paginatedField] = true;
+        }
+
         return [
             {
                 $match: filter
@@ -191,19 +216,50 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 $sort: sort
             },
             {
-                $group: {
-                    _id: '$thread',
-                    message: {
-                        $first: '$$ROOT'
-                    }
-                }
+                $group: group
             },
             {
-                $replaceRoot: {
-                    newRoot: '$message'
-                }
+                $project: tupleProjection
             }
         ];
+    };
+
+    const getCollapsedListing = async (filter, { limit, projection, paginatedField, sortAscending, next, previous, maxTimeMS }) => {
+        const listingWrapper = await mongopagingAggregateWrapper(db.database.collection('messages'), {
+            pipeline: getCollapsedMessagePipeline(filter, sortAscending, paginatedField),
+            limit,
+            paginatedField,
+            sortAscending,
+            next,
+            previous,
+            aggregateOptions: {
+                allowDiskUse: true,
+                maxTimeMS
+            }
+        });
+
+        const tuples = listingWrapper.listing.results || [];
+        if (tuples.length) {
+            const documentQuery = { _id: { $in: tuples.map(tuple => tuple._id) } };
+
+            // keep equality keys from the original filter so the query stays routed
+            // to the shards that hold this mailbox instead of hitting every shard
+            for (const routingKey of ['mailbox', 'user']) {
+                if (filter[routingKey] && typeof filter[routingKey].toHexString === 'function') {
+                    documentQuery[routingKey] = filter[routingKey];
+                }
+            }
+
+            const documents = await db.database
+                .collection('messages')
+                .find(documentQuery, { projection, maxTimeMS })
+                .toArray();
+
+            const documentMap = new Map(documents.map(messageData => [messageData._id.toString(), messageData]));
+            listingWrapper.listing.results = tuples.map(tuple => documentMap.get(tuple._id.toString())).filter(messageData => messageData);
+        }
+
+        return listingWrapper;
     };
 
     const applyBimiToListing = async messages => {
@@ -669,18 +725,14 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let listingWrapper;
             try {
                 listingWrapper = collapseThreads
-                    ? await mongopagingAggregateWrapper(db.database.collection('messages'), {
-                          pipeline: getCollapsedMessagePipeline(filter, sortAscending),
+                    ? await getCollapsedListing(filter, {
                           limit,
                           projection,
                           paginatedField: 'idate',
                           sortAscending,
                           next: pageNext,
                           previous: pagePrevious,
-                          aggregateOptions: {
-                              allowDiskUse: true,
-                              maxTimeMS: consts.DB_MAX_TIME_MESSAGES
-                          }
+                          maxTimeMS: consts.DB_MAX_TIME_MESSAGES
                       })
                     : await mongopagingFindWrapper(db.database.collection('messages'), opts);
             } catch (err) {
@@ -999,18 +1051,14 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                     return mongopagingFindWrapper(db.database.collection('messages'), opts);
                 }
 
-                return mongopagingAggregateWrapper(db.database.collection('messages'), {
-                    pipeline: getCollapsedMessagePipeline(filter, sortAscending, paginatedField),
+                return getCollapsedListing(filter, {
                     limit,
                     projection: opts.fields.projection,
                     paginatedField,
                     sortAscending,
                     next: pageNext,
                     previous: pagePrevious,
-                    aggregateOptions: {
-                        allowDiskUse: true,
-                        maxTimeMS
-                    }
+                    maxTimeMS
                 });
             };
 

--- a/test/api/webauthn-test.js
+++ b/test/api/webauthn-test.js
@@ -130,7 +130,7 @@ function base64UrlDecode(value) {
     return Buffer.from(input, 'base64');
 }
 
-describe.only('API WebAuthn', function () {
+describe('API WebAuthn', function () {
     this.timeout(10000); // eslint-disable-line no-invalid-this
 
     const password = 'webauthnsecretvalue';


### PR DESCRIPTION
## Problem

The `collapseThreads` message listing groups whole documents with `$first: '$$ROOT'`. On a sharded cluster everything after the per-shard sort runs on a single merging node, so every page view ships the entire mailbox to one shard and spills the `$group` stage to disk (the merge payload exceeds the 100 MB group memory limit as soon as the mailbox holds more than a few thousand messages).

Measured on a production cluster (MongoDB 6.0, 20+ shards): a 13.9k message inbox moved 1.2 GB (avg 90 KB per message document) through the merging shard on every page view, taking 5.5s, with the cost growing linearly with mailbox size. The per-shard scans themselves were already optimal (~120 ms, zero scan amplification via `by_idate_reverse_uid`). 97% of threads were singletons, so the row count reduction from collapsing is negligible; the payload size is the whole problem.

## Fix

- The collapse aggregation now carries only `{_id, idate}` tuples of each thread's newest message. The documents for the returned page are fetched afterwards by `_id` (with the mailbox/user equality keys kept in the query so it stays routed to the right shards).
- New `by_idate_reverse_thread` index `{mailbox: 1, idate: -1, _id: -1, thread: 1, uid: 1}` makes both the listing and the collapsed count aggregations fully covered (`docsExamined: 0`). `uid` is included so the SHARDING_FILTER stage on sharded clusters can run off index entries instead of forcing a fetch of every document.
- Adds the missing `archived` `{user, thread}` index that backs the `threadCounters` lookup on archived message listings.

Merge payload drops from ~90 KB to ~50 bytes per message (a 500k mailbox moves ~25 MB instead of ~45 GB), and the second full-mailbox document scan per request (the `total` count) disappears.

Paging cursors keep the exact same format, so cursors issued by the old implementation keep working during a rolling deploy.

Also removes a committed `describe.only` in `test/api/webauthn-test.js` that silently reduced the grunt `api` test target to 8 WebAuthn tests.

## Deployment notes

The new index on `messages` is a large build on big deployments, so create both indexes manually **before merging and deploying**. The name and key spec below match `indexes.yaml` exactly, which makes the application's index setup on startup a no-op instead of kicking off an hours-long build.

Index builds run server-side as online hybrid builds (no collection lock) and are not tied to the client connection: once `createIndexes` reaches the server, the build runs to completion even if the client disconnects. Only the `createIndex` shell call waits, so start it detached and disconnect (adjust the mongos URI and database name to your deployment):

```bash
db.getSiblingDB("wildduck").messages.createIndex(
    { mailbox: 1, idate: -1, _id: -1, thread: 1, uid: 1 },
    { name: "by_idate_reverse_thread" }
);
db.getSiblingDB("wildduck").archived.createIndex(
    { user: 1, thread: 1 },
    { name: "user_messages_by_thread" }
);
```

Progress can be watched with:

```js
db.getSiblingDB('admin').aggregate([{ $currentOp: { allUsers: true } }, { $match: { 'command.createIndexes': { $exists: true } } }]);
```