### PR TITLE
fix filter handler overrides and filter precedence

### DIFF
--- a/lib/filter-handler.js
+++ b/lib/filter-handler.js
@@ -654,7 +654,17 @@ class FilterHandler {
             });
         }
 
-        if (typeof userData.spamLevel === 'number' && userData.spamLevel >= 0) {
+        const hasMailboxFilterAction = !!filterActions.get('mailbox');
+
+        if (hasMailboxFilterAction && filterActions.get('spam') > 0) {
+            // An explicit filter destination takes precedence over moving the message to Junk.
+            filterActions.delete('spam');
+            spamActionSource = false;
+            spamActionDomainaccess = false;
+            spamActionFilter = false;
+        }
+
+        if (!hasMailboxFilterAction && typeof userData.spamLevel === 'number' && userData.spamLevel >= 0) {
             let isSpam;
 
             if (userData.spamLevel === 0) {
@@ -700,7 +710,7 @@ class FilterHandler {
         }
 
         const overrideFlags = Array.isArray(meta?.overrides?.flags) ? meta.overrides.flags : false;
-        if (overrideFlags && spamActionSource !== 'filter') {
+        if (overrideFlags && !hasMailboxFilterAction && spamActionSource !== 'filter') {
             // Recipient-level overrides may only replace domainaccess and user spamLevel decisions.
             originalSpam = filterActions.get('spam') === true;
             if (overrideFlags.includes('ham')) {

--- a/test/filter-handler-overrides-test.js
+++ b/test/filter-handler-overrides-test.js
@@ -390,6 +390,57 @@ describe('FilterHandler recipient spam overrides', () => {
         expect(getSpamResult(result)).to.not.exist;
     });
 
+    it('should not let a spam override replace a filter mailbox destination', async () => {
+        const mailbox = new ObjectId();
+        const { addOptions, result } = await runCase({
+            overrideFlags: ['spam'],
+            filters: [
+                {
+                    _id: new ObjectId(),
+                    query: {
+                        headers: {
+                            from: 'alice@example.com'
+                        }
+                    },
+                    action: {
+                        mailbox
+                    }
+                }
+            ]
+        });
+
+        expect(addOptions.mailbox).to.equal(mailbox);
+        expect(addOptions.path).to.not.exist;
+        expect(addOptions.specialUse).to.not.exist;
+        expect(getSpamResult(result)).to.not.exist;
+    });
+
+    it('should prefer a filter mailbox destination over a spam action', async () => {
+        const mailbox = new ObjectId();
+        const { addOptions, result } = await runCase({
+            filters: [
+                {
+                    _id: new ObjectId(),
+                    query: {
+                        headers: {
+                            from: 'alice@example.com'
+                        }
+                    },
+                    action: {
+                        mailbox,
+                        spam: true
+                    }
+                }
+            ]
+        });
+
+        expect(addOptions.mailbox).to.equal(mailbox);
+        expect(addOptions.path).to.not.exist;
+        expect(addOptions.specialUse).to.not.exist;
+        expect(getSpamResult(result)).to.not.exist;
+        expect(addOptions.prepared.mimeTree.header.some(header => /^WD-Mail-Classification:/i.test(header))).to.equal(false);
+    });
+
     it('should prefer ham when mixed with spam-like override flags', async () => {
         const { addOptions } = await runCase({
             overrideFlags: ['blacklist', 'ham']


### PR DESCRIPTION
in case of a move filter is always higher precedence than marking as spam, both if coming from filter or from overrides