### PR TITLE
fix(api-put-queue): ZMS-87 add endpoint to update message in queue

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,6 +52,7 @@ module.exports = function (grunt) {
                     'test/filtering-tools-test.js',
                     'test/hibp-tools-test.js',
                     'test/list-headers-test.js',
+                    'test/maildropper-test.js',
                     'test/tools-test.js'
                 ]
             },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -53,6 +53,8 @@ module.exports = function (grunt) {
                     'test/filtering-tools-test.js',
                     'test/hibp-tools-test.js',
                     'test/list-headers-test.js',
+                    'test/maildropper-test.js',
+                    'test/message-handler-update-test.js',
                     'test/metrics-config-test.js',
                     'test/prometheus-test.js',
                     'test/tools-test.js'

--- a/config/sender.toml
+++ b/config/sender.toml
@@ -13,3 +13,8 @@ collection="zone-queue"
 # Must be shared with haraka-plugin-wildduck
 # If not set then looping is not tracked
 #loopSecret="secret value"
+
+# How long a message is allowed to stay in the queue before the MTA drops it, in milliseconds.
+# Scheduling a delivery past this point is rejected, as the MTA expires queue entries by insertion
+# time and does so without generating a bounce. Must match the `maxQueueTime` value of ZoneMTA
+maxQueueTime=2592000000

--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -4341,7 +4341,7 @@
                     "Messages"
                 ],
                 "summary": "Update an Outbound Message",
-                "description": "Updates the delivery time of an outbound email that is still queued.",
+                "description": "Updates the delivery time of an outbound email that is still queued. Delivery times in the past are replaced with the current time. Queue entries that are already being delivered can not be updated.",
                 "operationId": "updateOutboundMessage",
                 "requestBody": {
                     "content": {
@@ -12197,6 +12197,11 @@
                     "queueId": {
                         "type": "string",
                         "description": "Outbound queue ID"
+                    },
+                    "sendTime": {
+                        "type": "string",
+                        "description": "Delivery time that was applied. Delivery times in the past are replaced with the current time",
+                        "format": "date-time"
                     },
                     "updated": {
                         "type": "number",

--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -6,7 +6,7 @@
         "contact": {
             "url": "https://github.com/zone-eu/wildduck"
         },
-        "version": "1.48.2"
+        "version": "1.50.0"
     },
     "servers": [
         {
@@ -2789,6 +2789,26 @@
                         }
                     },
                     {
+                        "name": "includeHasDrafts",
+                        "in": "query",
+                        "description": "If true, then calculates and includes hasDrafts in the response. This comes with some overhead",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "collapseThreads",
+                        "in": "query",
+                        "description": "If true, then returns only the newest or oldest message from each thread, depending on the order argument",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
                         "name": "limit",
                         "in": "query",
                         "description": "How many records to return",
@@ -2909,6 +2929,11 @@
                                     "flagged": {
                                         "type": "boolean",
                                         "description": "State of the \\Flagged flag"
+                                    },
+                                    "markHam": {
+                                        "type": "boolean",
+                                        "description": "If true then emits the marked.ham webhook for matched messages. Setting flagged=true also emits marked.ham",
+                                        "default": false
                                     },
                                     "draft": {
                                         "type": "boolean",
@@ -3474,6 +3499,26 @@
                         }
                     },
                     {
+                        "name": "includeHasDrafts",
+                        "in": "query",
+                        "description": "If true, then calculates and includes hasDrafts in the response. This comes with some overhead",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "collapseThreads",
+                        "in": "query",
+                        "description": "If true, then returns only the newest or oldest matching message from each thread, depending on the order argument",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
                         "name": "limit",
                         "in": "query",
                         "description": "How many records to return",
@@ -3832,6 +3877,11 @@
                                     "flagged": {
                                         "type": "boolean",
                                         "description": "State of the \\Flagged flag"
+                                    },
+                                    "markHam": {
+                                        "type": "boolean",
+                                        "description": "If true then emits the marked.ham webhook for matched messages. Setting flagged=true also emits marked.ham",
+                                        "default": false
                                     },
                                     "draft": {
                                         "type": "boolean",
@@ -4286,6 +4336,84 @@
             }
         },
         "/users/{user}/outbound/{queueId}": {
+            "put": {
+                "tags": [
+                    "Messages"
+                ],
+                "summary": "Update an Outbound Message",
+                "description": "Updates the delivery time of an outbound email that is still queued.",
+                "operationId": "updateOutboundMessage",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "sendTime": {
+                                        "type": "string",
+                                        "description": "New delivery time for the queued message",
+                                        "format": "date-time"
+                                    }
+                                },
+                                "required": [
+                                    "sendTime"
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "Example: `507f1f77bcf86cd799439011`\nID of the User",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "queueId",
+                        "in": "path",
+                        "description": "Outbound queue ID of the message",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sess",
+                        "in": "query",
+                        "description": "Session identifier for the logs",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ip",
+                        "in": "query",
+                        "description": "IP address for the logs ",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UpdateOutboundMessageResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "delete": {
                 "tags": [
                     "Messages"
@@ -7416,7 +7544,7 @@
                                     },
                                     "isDraft": {
                                         "type": "boolean",
-                                        "description": "Is the message a draft or not",
+                                        "description": "If true then stores the message as a draft without queueing delivery",
                                         "default": false
                                     },
                                     "draft": {
@@ -12056,6 +12184,31 @@
                 "required": [
                     "success",
                     "queueId"
+                ]
+            },
+            "UpdateOutboundMessageResponse": {
+                "type": "object",
+                "properties": {
+                    "success": {
+                        "type": "boolean",
+                        "description": "Indicates successful response",
+                        "example": true
+                    },
+                    "queueId": {
+                        "type": "string",
+                        "description": "Outbound queue ID"
+                    },
+                    "updated": {
+                        "type": "number",
+                        "description": "Count of updated queue entries"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "Error code if the request failed"
+                    }
+                },
+                "required": [
+                    "success"
                 ]
             },
             "GetArchivedMessagesResponse": {

--- a/docs/api/openapidocs.json
+++ b/docs/api/openapidocs.json
@@ -9128,6 +9128,13 @@
                     }
                 }
             }
+        },
+        "/api-methods": {
+            "get": {
+                "operationId": "api-methods",
+                "parameters": [],
+                "responses": {}
+            }
         }
     },
     "components": {
@@ -12207,9 +12214,13 @@
                         "type": "number",
                         "description": "Count of updated queue entries"
                     },
-                    "code": {
-                        "type": "string",
-                        "description": "Error code if the request failed"
+                    "dateUpdated": {
+                        "type": "boolean",
+                        "description": "If true then the Date header of the queued message was set to the new delivery time. Only messages submitted by the user are rewritten, forwards and autoreplies keep the Date value of the original message"
+                    },
+                    "storedUpdated": {
+                        "type": "number",
+                        "description": "Count of stored copies of the message, eg. in the Sent Mail folder, that were updated"
                     }
                 },
                 "required": [

--- a/indexer.js
+++ b/indexer.js
@@ -106,6 +106,13 @@ class Indexer {
                     modseq: entry.modseq,
                     user: entry.user.toString()
                 };
+                // a rescheduled message has its Date header rewritten, which also changes its stored size
+                if (entry.hdate) {
+                    payload.hdate = entry.hdate.toISOString();
+                }
+                if (typeof entry.size === 'number') {
+                    payload.size = entry.size;
+                }
                 break;
         }
 
@@ -505,6 +512,12 @@ function indexingJob(esclient) {
                                         ctx._source.flags = params.flags;
                                         ctx._source.unseen = params.unseen;
                                         ctx._source.modseq = params.modseq;
+                                        if (params.hdate != null) {
+                                            ctx._source.hdate = params.hdate;
+                                        }
+                                        if (params.size != null) {
+                                            ctx._source.size = params.size;
+                                        }
                                     }
                                 `,
                                 params: {
@@ -512,7 +525,11 @@ function indexingJob(esclient) {
                                     draft: data.flags.includes('\\Draft'),
                                     flagged: data.flags.includes('\\Flagged'),
                                     flags: data.flags || [],
-                                    unseen: !data.flags.includes('\\Seen')
+                                    unseen: !data.flags.includes('\\Seen'),
+                                    // only set when the message content changed, eg. a queued message was rescheduled
+                                    hdate: data.hdate || null,
+
+                                    size: typeof data.size === 'number' ? data.size : null
                                 }
                             }
                         };

--- a/indexes.yaml
+++ b/indexes.yaml
@@ -251,6 +251,17 @@ indexes:
 
     - collection: messages
       index:
+          # Queue IDs are selective, so keep this index to one key and exclude ordinary received messages.
+          # The matching document provides mailbox and uid for the shard-targeted notified update.
+          name: outbound_message
+          key:
+              outbound: 1
+          partialFilterExpression:
+              outbound:
+                  $exists: true
+
+    - collection: messages
+      index:
           # use also as sharding key
           name: mailbox_uid
           key:

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -3535,6 +3535,79 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
         })
     );
 
+    server.put(
+        {
+            path: '/users/:user/outbound/:queueId',
+            tags: ['Messages'],
+            summary: 'Update an Outbound Message',
+            name: 'updateOutboundMessage',
+            description: 'Updates the delivery time of an outbound email that is still queued.',
+            validationObjs: {
+                requestBody: {
+                    sendTime: Joi.date().required().description('New delivery time for the queued message')
+                },
+                queryParams: {
+                    sess: sessSchema,
+                    ip: sessIPSchema
+                },
+                pathParams: {
+                    user: userId,
+                    queueId: Joi.string().hex().lowercase().min(18).max(24).required().description('Outbound queue ID of the message')
+                },
+                response: {
+                    200: {
+                        description: 'Success',
+                        model: Joi.object({
+                            success: successRes,
+                            queueId: Joi.string().description('Outbound queue ID'),
+                            updated: Joi.number().description('Count of updated queue entries'),
+                            code: Joi.string().description('Error code if the request failed')
+                        }).$_setFlag('objectName', 'UpdateOutboundMessageResponse')
+                    }
+                }
+            }
+        },
+        tools.responseWrapper(async (req, res) => {
+            res.charSet('utf-8');
+
+            const { pathParams, requestBody, queryParams } = req.route.spec.validationObjs;
+
+            const schema = Joi.object({
+                ...pathParams,
+                ...queryParams,
+                ...requestBody
+            });
+
+            const result = schema.validate(req.params, {
+                abortEarly: false,
+                convert: true
+            });
+
+            if (result.error) {
+                res.status(400);
+                return res.json({
+                    error: result.error.message,
+                    code: 'InputValidationError',
+                    details: tools.validationErrors(result)
+                });
+            }
+
+            // permissions check
+            if (req.user && req.user === result.value.user) {
+                req.validate(roles.can(req.role).updateOwn('messages'));
+            } else {
+                req.validate(roles.can(req.role).updateAny('messages'));
+            }
+
+            let user = new ObjectId(result.value.user);
+            let queueId = result.value.queueId;
+
+            let response = await maildrop.updateQueueTime(queueId, user, result.value.sendTime);
+
+            return res.json(response);
+        })
+    );
+
     server.del(
         {
             path: '/users/:user/outbound/:queueId',

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -109,6 +109,45 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
         return projection;
     };
 
+    const updateStoredOutboundDate = async (user, queueId, sendTime) => {
+        let cursor = db.database
+            .collection('messages')
+            .find({
+                user,
+                outbound: queueId
+            })
+            .project({
+                _id: false,
+                mailbox: true,
+                uid: true
+            });
+
+        let messagesByMailbox = new Map();
+        let messageData;
+        while ((messageData = await cursor.next())) {
+            if (!messageData.mailbox || !Number.isInteger(messageData.uid) || messageData.uid < 1) {
+                continue;
+            }
+
+            let mailboxId = messageData.mailbox.toString();
+            if (!messagesByMailbox.has(mailboxId)) {
+                messagesByMailbox.set(mailboxId, {
+                    mailbox: messageData.mailbox,
+                    uids: new Set()
+                });
+            }
+            messagesByMailbox.get(mailboxId).uids.add(messageData.uid);
+        }
+
+        await Promise.all(
+            Array.from(messagesByMailbox.values()).map(messageGroup => {
+                let uids = Array.from(messageGroup.uids);
+                let messageQuery = uids.length === 1 ? uids[0] : { $in: uids };
+                return updateMessage(user, messageGroup.mailbox, messageQuery, { date: sendTime });
+            })
+        );
+    };
+
     const addThreadCountersToMessageList = async (
         user,
         list,
@@ -3272,36 +3311,21 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 sendTime = now;
             }
 
-            // update message headers, use updated Date value
-            if (messageData.mimeTree.header) {
-                let headerFound = false;
-                for (let i = 0; i < messageData.mimeTree.header.length; i++) {
-                    if (/^date\s*:/i.test(messageData.mimeTree.header[i])) {
-                        headerFound = true;
-                        messageData.mimeTree.header[i] = `Date: ${tools.formatDateHeader(sendTime)}`;
-                    }
-                }
-                if (!headerFound) {
-                    messageData.mimeTree.header.push(`Date: ${tools.formatDateHeader(sendTime)}`);
-                }
+            // Update the Draft message entry. This is later moved to Sent Mail, so every stored Date
+            // representation must match the scheduled delivery time.
+            let messageDateUpdate = messageHandler.getMessageDateUpdate(messageData, sendTime);
+            messageData.mimeTree.header = messageDateUpdate['mimeTree.header'];
+            messageData.mimeTree.parsedHeader.date = sendTime;
+            messageData.envelope = messageDateUpdate.envelope;
 
-                messageData.mimeTree.parsedHeader.date = sendTime;
-
-                // update Draft message entry. This is later moved to Sent Mail folder so the Date values
-                // must be correct ones
-                await db.database.collection('messages').updateOne(
-                    {
-                        _id: messageData._id
-                    },
-                    {
-                        $set: {
-                            'mimeTree.header': messageData.mimeTree.header,
-                            'mimeTree.parsedHeader.date': sendTime,
-                            hdate: sendTime
-                        }
-                    }
-                );
-            }
+            await db.database.collection('messages').updateOne(
+                {
+                    _id: messageData._id
+                },
+                {
+                    $set: messageDateUpdate
+                }
+            );
 
             let envelope = messageData.meta.envelope;
             if (!envelope) {
@@ -3611,7 +3635,8 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 sendTime = now;
             }
 
-            let response = await maildrop.updateQueueTime(queueId, user, sendTime);
+            let queueResponse = await maildrop.updateQueueTime(queueId, user, sendTime);
+            let { submitted, ...response } = queueResponse;
 
             if (!response.success) {
                 // the sibling DELETE route returns these with HTTP 200 for backwards compatibility, new routes do not
@@ -3627,6 +3652,10 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         res.status(409);
                 }
                 return res.json(response);
+            }
+
+            if (submitted) {
+                await updateStoredOutboundDate(user, queueId, sendTime);
             }
 
             server.loggelf({

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -34,7 +34,7 @@ const {
     AddressOptionalName,
     ReferenceWithoutAttachments
 } = require('../schemas/request/messages-schemas');
-const { userId, mailboxId, messageId } = require('../schemas/request/general-schemas');
+const { userId, mailboxId, messageId, queueId: queueIdSchema } = require('../schemas/request/general-schemas');
 const { MsgEnvelope, MsgVerificationResults } = require('../schemas/response/messages-schemas');
 const { successRes } = require('../schemas/response/general-schemas');
 const { mongopagingFindWrapper, mongopagingAggregateWrapper } = require('../mongopaging-find-wrapper');
@@ -3278,11 +3278,11 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 for (let i = 0; i < messageData.mimeTree.header.length; i++) {
                     if (/^date\s*:/i.test(messageData.mimeTree.header[i])) {
                         headerFound = true;
-                        messageData.mimeTree.header[i] = `Date: ${sendTime.toUTCString().replace(/GMT/, '+0000')}`;
+                        messageData.mimeTree.header[i] = `Date: ${tools.formatDateHeader(sendTime)}`;
                     }
                 }
                 if (!headerFound) {
-                    messageData.mimeTree.header.push(`Date: ${sendTime.toUTCString().replace(/GMT/, '+0000')}`);
+                    messageData.mimeTree.header.push(`Date: ${tools.formatDateHeader(sendTime)}`);
                 }
 
                 messageData.mimeTree.parsedHeader.date = sendTime;
@@ -3541,7 +3541,8 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             tags: ['Messages'],
             summary: 'Update an Outbound Message',
             name: 'updateOutboundMessage',
-            description: 'Updates the delivery time of an outbound email that is still queued.',
+            description:
+                'Updates the delivery time of an outbound email that is still queued. Delivery times in the past are replaced with the current time. Queue entries that are already being delivered can not be updated.',
             validationObjs: {
                 requestBody: {
                     sendTime: Joi.date().required().description('New delivery time for the queued message')
@@ -3552,7 +3553,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 },
                 pathParams: {
                     user: userId,
-                    queueId: Joi.string().hex().lowercase().min(18).max(24).required().description('Outbound queue ID of the message')
+                    queueId: queueIdSchema
                 },
                 response: {
                     200: {
@@ -3560,6 +3561,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                         model: Joi.object({
                             success: successRes,
                             queueId: Joi.string().description('Outbound queue ID'),
+                            sendTime: Joi.date().description('Delivery time that was applied. Delivery times in the past are replaced with the current time'),
                             updated: Joi.number().description('Count of updated queue entries'),
                             code: Joi.string().description('Error code if the request failed')
                         }).$_setFlag('objectName', 'UpdateOutboundMessageResponse')
@@ -3602,9 +3604,43 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             let user = new ObjectId(result.value.user);
             let queueId = result.value.queueId;
 
-            let response = await maildrop.updateQueueTime(queueId, user, result.value.sendTime);
+            let sendTime = result.value.sendTime;
+            let now = new Date();
+            if (sendTime < now) {
+                // do not allow to set a delivery time in the past
+                sendTime = now;
+            }
 
-            return res.json(response);
+            let response = await maildrop.updateQueueTime(queueId, user, sendTime);
+
+            if (!response.success) {
+                // the sibling DELETE route returns these with HTTP 200 for backwards compatibility, new routes do not
+                switch (response.code) {
+                    case 'NoSuchQueueEntry':
+                        res.status(404);
+                        break;
+                    case 'NotEnoughPrivileges':
+                        res.status(403);
+                        break;
+                    default:
+                        // message is already being delivered
+                        res.status(409);
+                }
+                return res.json(response);
+            }
+
+            server.loggelf({
+                short_message: '[QUEUE] update',
+                _mail_action: 'update_queued',
+                _user: user.toString(),
+                _queue_id: queueId,
+                _send_time: sendTime.toISOString(),
+                _queue_entries: response.updated,
+                _sess: result.value.sess,
+                _ip: result.value.ip
+            });
+
+            return res.json({ ...response, sendTime });
         })
     );
 
@@ -3623,7 +3659,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 },
                 pathParams: {
                     user: userId,
-                    queueId: Joi.string().hex().lowercase().min(18).max(24).required().description('Outbound queue ID of the message')
+                    queueId: queueIdSchema
                 },
                 response: {
                     200: {

--- a/lib/api/messages.js
+++ b/lib/api/messages.js
@@ -47,6 +47,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
         zone: config.sender.zone,
         collection: config.sender.collection,
         gfs: config.sender.gfs,
+        maxQueueTime: config.sender.maxQueueTime,
         loopSecret: config.sender.loopSecret
     });
 
@@ -109,8 +110,12 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
         return projection;
     };
 
+    // Updates the stored copies of a queued message, eg. the entry in the Sent Mail folder, to match
+    // the delivery time of the queue entry. Returns the count of messages that were updated.
     const updateStoredOutboundDate = async (user, queueId, sendTime) => {
-        let cursor = db.database
+        // a queue ID is referenced by the stored copy of the submitted message and, for forwards and
+        // autoreplies, by the message that triggered these, so this is a handful of documents at most
+        let messages = await db.database
             .collection('messages')
             .find({
                 user,
@@ -120,32 +125,15 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 _id: false,
                 mailbox: true,
                 uid: true
-            });
+            })
+            .toArray();
 
-        let messagesByMailbox = new Map();
-        let messageData;
-        while ((messageData = await cursor.next())) {
-            if (!messageData.mailbox || !Number.isInteger(messageData.uid) || messageData.uid < 1) {
-                continue;
-            }
-
-            let mailboxId = messageData.mailbox.toString();
-            if (!messagesByMailbox.has(mailboxId)) {
-                messagesByMailbox.set(mailboxId, {
-                    mailbox: messageData.mailbox,
-                    uids: new Set()
-                });
-            }
-            messagesByMailbox.get(mailboxId).uids.add(messageData.uid);
+        let updated = 0;
+        for (let messageData of messages) {
+            updated += await updateMessage(user, messageData.mailbox, messageData.uid, { date: sendTime });
         }
 
-        await Promise.all(
-            Array.from(messagesByMailbox.values()).map(messageGroup => {
-                let uids = Array.from(messageGroup.uids);
-                let messageQuery = uids.length === 1 ? uids[0] : { $in: uids };
-                return updateMessage(user, messageGroup.mailbox, messageQuery, { date: sendTime });
-            })
-        );
+        return updated;
     };
 
     const addThreadCountersToMessageList = async (
@@ -330,10 +318,7 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 }
             }
 
-            const documents = await db.database
-                .collection('messages')
-                .find(documentQuery, { projection, maxTimeMS })
-                .toArray();
+            const documents = await db.database.collection('messages').find(documentQuery, { projection, maxTimeMS }).toArray();
 
             const documentMap = new Map(documents.map(messageData => [messageData._id.toString(), messageData]));
             listingWrapper.listing.results = tuples.map(tuple => documentMap.get(tuple._id.toString())).filter(messageData => messageData);
@@ -3313,19 +3298,16 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
 
             // Update the Draft message entry. This is later moved to Sent Mail, so every stored Date
             // representation must match the scheduled delivery time.
-            let messageDateUpdate = messageHandler.getMessageDateUpdate(messageData, sendTime);
+            // Persist the new date through the shared path, which also handles the size accounting, the
+            // MODSEQ bump and the notifications. The in-memory copy is refreshed separately, as the rebuilt
+            // message is composed from the header list and the size is reported back to the caller.
+            let { update: messageDateUpdate } = messageHandler.getMessageDateUpdate(messageData, sendTime);
             messageData.mimeTree.header = messageDateUpdate['mimeTree.header'];
-            messageData.mimeTree.parsedHeader.date = sendTime;
-            messageData.envelope = messageDateUpdate.envelope;
+            if (typeof messageDateUpdate.size === 'number') {
+                messageData.size = messageDateUpdate.size;
+            }
 
-            await db.database.collection('messages').updateOne(
-                {
-                    _id: messageData._id
-                },
-                {
-                    $set: messageDateUpdate
-                }
-            );
+            await updateMessage(user, mailbox, messageData.uid, { date: sendTime });
 
             let envelope = messageData.meta.envelope;
             if (!envelope) {
@@ -3587,7 +3569,10 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                             queueId: Joi.string().description('Outbound queue ID'),
                             sendTime: Joi.date().description('Delivery time that was applied. Delivery times in the past are replaced with the current time'),
                             updated: Joi.number().description('Count of updated queue entries'),
-                            code: Joi.string().description('Error code if the request failed')
+                            dateUpdated: booleanSchema.description(
+                                'If true then the Date header of the queued message was set to the new delivery time. Only messages submitted by the user are rewritten, forwards and autoreplies keep the Date value of the original message'
+                            ),
+                            storedUpdated: Joi.number().description('Count of stored copies of the message, eg. in the Sent Mail folder, that were updated')
                         }).$_setFlag('objectName', 'UpdateOutboundMessageResponse')
                     }
                 }
@@ -3636,26 +3621,44 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
             }
 
             let queueResponse = await maildrop.updateQueueTime(queueId, user, sendTime);
-            let { submitted, ...response } = queueResponse;
 
-            if (!response.success) {
+            if (!queueResponse.success) {
                 // the sibling DELETE route returns these with HTTP 200 for backwards compatibility, new routes do not
-                switch (response.code) {
+                let error;
+                switch (queueResponse.code) {
                     case 'NoSuchQueueEntry':
                         res.status(404);
+                        error = 'No such queue entry';
                         break;
                     case 'NotEnoughPrivileges':
                         res.status(403);
+                        error = 'Not enough privileges';
+                        break;
+                    case 'SendTimeTooLate':
+                        res.status(400);
+                        error = `Delivery time can not be later than ${queueResponse.maxSendTime.toISOString()}`;
                         break;
                     default:
-                        // message is already being delivered
+                        // some of the queue entries are already being delivered
                         res.status(409);
+                        error = 'Message is already being delivered';
                 }
-                return res.json(response);
+
+                return res.json({ success: false, error, code: queueResponse.code });
             }
 
-            if (submitted) {
-                await updateStoredOutboundDate(user, queueId, sendTime);
+            let storedUpdated = 0;
+            if (queueResponse.dateUpdated) {
+                // the queue entry is already rescheduled, so a failure here only leaves the stored copies stale
+                try {
+                    storedUpdated = await updateStoredOutboundDate(user, queueId, sendTime);
+                } catch (err) {
+                    res.status(500);
+                    return res.json({
+                        error: err.message,
+                        code: err.code || 'InternalDatabaseError'
+                    });
+                }
             }
 
             server.loggelf({
@@ -3664,12 +3667,13 @@ module.exports = (db, server, messageHandler, userHandler, storageHandler, setti
                 _user: user.toString(),
                 _queue_id: queueId,
                 _send_time: sendTime.toISOString(),
-                _queue_entries: response.updated,
+                _queue_entries: queueResponse.updated,
+                _stored_messages: storedUpdated,
                 _sess: result.value.sess,
                 _ip: result.value.ip
             });
 
-            return res.json({ ...response, sendTime });
+            return res.json({ ...queueResponse, sendTime, storedUpdated });
         })
     );
 

--- a/lib/api/submit.js
+++ b/lib/api/submit.js
@@ -38,6 +38,7 @@ module.exports = (db, server, messageHandler, userHandler, settingsHandler) => {
         zone: config.sender.zone,
         collection: config.sender.collection,
         gfs: config.sender.gfs,
+        maxQueueTime: config.sender.maxQueueTime,
         loopSecret: config.sender.loopSecret
     });
 

--- a/lib/autoreply.js
+++ b/lib/autoreply.js
@@ -99,6 +99,11 @@ async function autoreply(options, autoreplyData) {
                             {
                                 parentId: options.parentId,
                                 reason: 'autoreply',
+
+                                // the queue ID of the autoreply is exposed to the user in the `outbound` array of the
+                                // triggering message, so the entry must be owned by the user to stay manageable over the API
+                                user: options.userData && options.userData._id,
+
                                 from: '',
                                 to: options.sender,
                                 interface: 'autoreplies',

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -138,6 +138,12 @@ module.exports = {
     // maximum number of filters per account
     MAX_FILTERS: 400,
 
+    // Default for the `sender.maxQueueTime` config value. How long a message is allowed to stay in the
+    // outbound queue before the MTA drops it. Must not be larger than the `maxQueueTime` value of the MTA
+    // (ZoneMTA defaults to 30 days), as the MTA expires queue entries by insertion time and does so
+    // without generating a bounce
+    MAX_QUEUE_TIME: 30 * 24 * 3600 * 1000,
+
     // maximum amount of mailboxes per user
     MAX_MAILBOXES: 1500,
 

--- a/lib/maildrop.js
+++ b/lib/maildrop.js
@@ -14,6 +14,7 @@ module.exports = (options, callback) => {
             zone: config.sender.zone,
             collection: config.sender.collection,
             gfs: config.sender.gfs,
+            maxQueueTime: config.sender.maxQueueTime,
             loopSecret: config.sender.loopSecret
         });
 

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -13,6 +13,7 @@ const addressparser = require('nodemailer/lib/addressparser');
 const punycode = require('punycode.js');
 const crypto = require('crypto');
 const tools = require('./tools');
+const consts = require('./consts');
 const plugins = require('./plugins');
 const PassThrough = require('stream').PassThrough;
 const util = require('util');
@@ -24,6 +25,7 @@ class Maildropper {
         this.zone = options.zone;
         this.collection = options.collection;
         this.gfs = options.gfs;
+        this.maxQueueTime = Number(options.maxQueueTime) || consts.MAX_QUEUE_TIME;
 
         this.gridstore =
             options.gridstore ||
@@ -583,7 +585,11 @@ class Maildropper {
 
     /**
      * Resolves the GridFS entry of a queued message and makes sure that it can be modified by the user.
-     * Messages that are not linked to any user, eg. autoreplies, can only be resolved without a user argument
+     *
+     * Ownership is normally taken from the queue metadata, but not every producer stamps it, and entries
+     * queued before a producer was fixed never will. A user therefore also owns a queue entry when one of
+     * their own messages references it, which is the relation that handed the queue ID to the user in the
+     * first place. Entries that are owned by somebody else are always rejected.
      *
      * @param {String} id Queue ID of the message
      * @param {ObjectId} [user] If set, then the queued message must belong to this user
@@ -598,11 +604,32 @@ class Maildropper {
             return { error: { success: false, code: 'NoSuchQueueEntry' } };
         }
 
+        if (!user) {
+            return { queueFile };
+        }
+
         // metadata is stored separately from the message, so it might not be set yet
         let queueUserId = queueFile.metadata && queueFile.metadata.data && queueFile.metadata.data.userId;
 
-        if (user && (!queueUserId || user.toString() !== queueUserId.toString())) {
-            // message does not belong to us
+        if (queueUserId) {
+            if (user.toString() !== queueUserId.toString()) {
+                // message belongs to another user
+                return { error: { success: false, code: 'NotEnoughPrivileges' } };
+            }
+            return { queueFile };
+        }
+
+        let referencedBy = await this.db.database.collection('messages').findOne(
+            {
+                user,
+                outbound: id
+            },
+            {
+                projection: { _id: true }
+            }
+        );
+
+        if (!referencedBy) {
             return { error: { success: false, code: 'NotEnoughPrivileges' } };
         }
 
@@ -610,7 +637,7 @@ class Maildropper {
     }
 
     async removeFromQueue(id, user) {
-        let { error } = await this.resolveQueueFile(id, user);
+        let { queueFile, error } = await this.resolveQueueFile(id, user);
 
         if (error) {
             return error;
@@ -623,20 +650,18 @@ class Maildropper {
         let stillQueued = await this.db.senderDb.collection(this.collection).countDocuments({ id });
         if (!stillQueued) {
             // delete gridstore file as there are no more queued queue entries
-            let gsFile = await this.db.senderDb.collection(this.gfs + '.files').findOne({
-                filename: 'message ' + id
-            });
-            if (gsFile) {
-                await this.gridstore.delete(gsFile._id);
-            }
+            await this.gridstore.delete(queueFile._id);
         }
-        // delete queue entries
 
         return { success: true, queueId: id, deleted };
     }
 
     /**
      * Updates the delivery time of a queued message
+     *
+     * All remaining queue entries of the message must be reschedulable. Entries that are locked for delivery keep
+     * the Date header they were queued with, so moving the shared Date header of a partially rescheduled message
+     * would hand those recipients a Date value from the future.
      *
      * @param {String} id Queue ID of the message
      * @param {ObjectId} [user] If set, then the queued message must belong to this user
@@ -650,7 +675,17 @@ class Maildropper {
             return error;
         }
 
-        // entries that are already locked are being delivered right now, so these can not be rescheduled
+        // The MTA expires queue entries by the time these were inserted and drops these without a bounce,
+        // so refuse delivery times that the message would never survive until
+        let maxSendTime = new Date(queueFile.uploadDate.getTime() + this.maxQueueTime);
+
+        if (sendTime > maxSendTime) {
+            return { success: false, code: 'SendTimeTooLate', maxSendTime };
+        }
+
+        // Entries that are locked are being delivered right now, so these can not be rescheduled. The delivery
+        // time is set before the Date header is updated, as an entry that is picked up in between still carries
+        // the previous Date value, which is in the past and therefore harmless.
         let queueUpdateRes = await this.db.senderDb.collection(this.collection).updateMany(
             {
                 id,
@@ -666,20 +701,22 @@ class Maildropper {
         // matched, not modified, as re-sending the same delivery time must not look like a failure
         let updated = queueUpdateRes.matchedCount;
 
-        if (!updated) {
-            // either all remaining entries are locked for delivery or the message was already sent
-            return { success: false, code: 'QueueEntryLocked' };
+        // Counting after the update also catches entries that were locked while we were writing
+        let pending = await this.db.senderDb.collection(this.collection).countDocuments({ id });
+
+        if (!pending) {
+            // the last entry was delivered while we were updating the message
+            return { success: false, code: 'NoSuchQueueEntry' };
         }
 
-        await this.updateQueuedDate(queueFile, sendTime);
-
-        let metadata = (queueFile.metadata && queueFile.metadata.data) || {};
-        let response = { success: true, queueId: id, updated };
-        if (metadata.reason === 'submit') {
-            response.submitted = true;
+        if (pending > updated) {
+            // some entries are being delivered right now, leave the Date header alone
+            return { success: false, code: 'QueueEntryLocked', updated, locked: pending - updated };
         }
 
-        return response;
+        let dateUpdated = await this.updateQueuedDate(queueFile, sendTime);
+
+        return { success: true, queueId: id, updated, dateUpdated };
     }
 
     /**
@@ -692,12 +729,13 @@ class Maildropper {
      *
      * @param {Object} queueFile GridFS entry of the queued message
      * @param {Date} sendTime New delivery time
+     * @returns {Boolean} True if the Date header was updated
      */
     async updateQueuedDate(queueFile, sendTime) {
         let metadata = (queueFile.metadata && queueFile.metadata.data) || {};
 
         if (metadata.reason !== 'submit' || !metadata.headers) {
-            return;
+            return false;
         }
 
         let headers = new Headers(metadata.headers);
@@ -716,6 +754,8 @@ class Maildropper {
                 }
             }
         );
+
+        return true;
     }
 }
 

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -673,7 +673,13 @@ class Maildropper {
 
         await this.updateQueuedDate(queueFile, sendTime);
 
-        return { success: true, queueId: id, updated };
+        let metadata = (queueFile.metadata && queueFile.metadata.data) || {};
+        let response = { success: true, queueId: id, updated };
+        if (metadata.reason === 'submit') {
+            response.submitted = true;
+        }
+
+        return response;
     }
 
     /**

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -612,6 +612,35 @@ class Maildropper {
 
         return { success: true, queueId: id, deleted };
     }
+
+    async updateQueueTime(id, user, sendTime) {
+        let queueFile = await this.db.senderDb.collection(this.gfs + '.files').findOne({
+            filename: 'message ' + id
+        });
+
+        if (!queueFile) {
+            return { success: false, code: 'NoSuchQueueEntry' };
+        }
+
+        if (user && queueFile.metadata.data.userId && user.toString() !== queueFile.metadata.data.userId.toString()) {
+            // message does not belong to us
+            return { success: false, code: 'NotEnoughPrivileges' };
+        }
+
+        let queueUpdateRes = await this.db.senderDb.collection(this.collection).updateMany(
+            {
+                id,
+                locked: false
+            },
+            {
+                $set: {
+                    queued: sendTime
+                }
+            }
+        );
+
+        return { success: true, queueId: id, updated: queueUpdateRes.modifiedCount };
+    }
 }
 
 module.exports = Maildropper;

--- a/lib/maildropper.js
+++ b/lib/maildropper.js
@@ -3,6 +3,7 @@
 const SeqIndex = require('@zone-eu/seq-index');
 const RelaxedBody = require('nodemailer/lib/dkim/relaxed-body');
 const MessageSplitter = require('./message-splitter');
+const Headers = require('@zone-eu/mailsplit').Headers;
 const seqIndex = new SeqIndex();
 const GridFSBucket = require('mongodb').GridFSBucket;
 const { randomUUID: uuid } = require('crypto');
@@ -489,7 +490,7 @@ class Maildropper {
         let dateVal = new Date(date);
 
         if (updateDate || !date || dateVal.toString() === 'Invalid Date' || dateVal < new Date(1000)) {
-            date = new Date().toUTCString().replace(/GMT/, '+0000');
+            date = tools.formatDateHeader(new Date());
             envelope.headers.remove('date'); // remove old empty or invalid values
             envelope.headers.add('Date', date);
         }
@@ -580,18 +581,39 @@ class Maildropper {
         );
     }
 
-    async removeFromQueue(id, user) {
+    /**
+     * Resolves the GridFS entry of a queued message and makes sure that it can be modified by the user.
+     * Messages that are not linked to any user, eg. autoreplies, can only be resolved without a user argument
+     *
+     * @param {String} id Queue ID of the message
+     * @param {ObjectId} [user] If set, then the queued message must belong to this user
+     * @returns {Object} Either {queueFile} or {error} where error is a response object with success:false
+     */
+    async resolveQueueFile(id, user) {
         let queueFile = await this.db.senderDb.collection(this.gfs + '.files').findOne({
             filename: 'message ' + id
         });
 
         if (!queueFile) {
-            return { success: false, code: 'NoSuchQueueEntry' };
+            return { error: { success: false, code: 'NoSuchQueueEntry' } };
         }
 
-        if (user && queueFile.metadata.data.userId && user.toString() !== queueFile.metadata.data.userId.toString()) {
+        // metadata is stored separately from the message, so it might not be set yet
+        let queueUserId = queueFile.metadata && queueFile.metadata.data && queueFile.metadata.data.userId;
+
+        if (user && (!queueUserId || user.toString() !== queueUserId.toString())) {
             // message does not belong to us
-            return { success: false, code: 'NotEnoughPrivileges' };
+            return { error: { success: false, code: 'NotEnoughPrivileges' } };
+        }
+
+        return { queueFile };
+    }
+
+    async removeFromQueue(id, user) {
+        let { error } = await this.resolveQueueFile(id, user);
+
+        if (error) {
+            return error;
         }
 
         // delete message entries that are not locked
@@ -613,20 +635,22 @@ class Maildropper {
         return { success: true, queueId: id, deleted };
     }
 
+    /**
+     * Updates the delivery time of a queued message
+     *
+     * @param {String} id Queue ID of the message
+     * @param {ObjectId} [user] If set, then the queued message must belong to this user
+     * @param {Date} sendTime New delivery time
+     * @returns {Object} Response object, either success:true with the count of updated queue entries or success:false with an error code
+     */
     async updateQueueTime(id, user, sendTime) {
-        let queueFile = await this.db.senderDb.collection(this.gfs + '.files').findOne({
-            filename: 'message ' + id
-        });
+        let { queueFile, error } = await this.resolveQueueFile(id, user);
 
-        if (!queueFile) {
-            return { success: false, code: 'NoSuchQueueEntry' };
+        if (error) {
+            return error;
         }
 
-        if (user && queueFile.metadata.data.userId && user.toString() !== queueFile.metadata.data.userId.toString()) {
-            // message does not belong to us
-            return { success: false, code: 'NotEnoughPrivileges' };
-        }
-
+        // entries that are already locked are being delivered right now, so these can not be rescheduled
         let queueUpdateRes = await this.db.senderDb.collection(this.collection).updateMany(
             {
                 id,
@@ -639,7 +663,53 @@ class Maildropper {
             }
         );
 
-        return { success: true, queueId: id, updated: queueUpdateRes.modifiedCount };
+        // matched, not modified, as re-sending the same delivery time must not look like a failure
+        let updated = queueUpdateRes.matchedCount;
+
+        if (!updated) {
+            // either all remaining entries are locked for delivery or the message was already sent
+            return { success: false, code: 'QueueEntryLocked' };
+        }
+
+        await this.updateQueuedDate(queueFile, sendTime);
+
+        return { success: true, queueId: id, updated };
+    }
+
+    /**
+     * Keeps the Date header of a submitted message in sync with the delivery time. Queued headers are stored
+     * separately from the message body and the MTA builds the outgoing message from these, so it is enough to
+     * update the stored header list.
+     *
+     * Only messages submitted by the user are updated. Forwarded and autoreply messages are left as is as these
+     * carry the Date value of the original message and might also have signatures that cover the Date header.
+     *
+     * @param {Object} queueFile GridFS entry of the queued message
+     * @param {Date} sendTime New delivery time
+     */
+    async updateQueuedDate(queueFile, sendTime) {
+        let metadata = (queueFile.metadata && queueFile.metadata.data) || {};
+
+        if (metadata.reason !== 'submit' || !metadata.headers) {
+            return;
+        }
+
+        let headers = new Headers(metadata.headers);
+        let date = tools.formatDateHeader(sendTime);
+
+        headers.update('Date', date);
+
+        await this.db.senderDb.collection(this.gfs + '.files').updateOne(
+            {
+                _id: queueFile._id
+            },
+            {
+                $set: {
+                    'metadata.data.headers': headers.getList(),
+                    'metadata.data.date': date
+                }
+            }
+        );
     }
 }
 

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1720,9 +1720,39 @@ class MessageHandler {
         });
     }
 
+    getMessageDateUpdate(message, sendTime) {
+        let formattedDate = tools.formatDateHeader(sendTime);
+        let headers = [].concat((message.mimeTree && message.mimeTree.header) || []);
+        let headerFound = false;
+
+        headers = headers.map(header => {
+            if (!/^date\s*:/i.test(header)) {
+                return header;
+            }
+
+            headerFound = true;
+            return `Date: ${formattedDate}`;
+        });
+
+        if (!headerFound) {
+            headers.push(`Date: ${formattedDate}`);
+        }
+
+        let envelope = [].concat(message.envelope || []);
+        envelope[0] = formattedDate;
+
+        return {
+            hdate: sendTime,
+            'mimeTree.header': headers,
+            'mimeTree.parsedHeader.date': sendTime,
+            envelope
+        };
+    }
+
     _update(user, mailbox, messageQuery, changes, callback) {
         let updates = { $set: {} };
         let update = false;
+        let updateDate = false;
         let addFlags = [];
         let removeFlags = [];
         let markHam = changes && (changes.markHam === true || changes.flagged === true);
@@ -1789,6 +1819,13 @@ class MessageHandler {
                     updates.$set['meta.custom'] = changes.metaData;
                     update = true;
                     break;
+
+                case 'date':
+                    updateDate = changes.date;
+                    updates.$set.hdate = changes.date;
+                    updates.$set['mimeTree.parsedHeader.date'] = changes.date;
+                    update = true;
+                    break;
             }
         });
 
@@ -1832,16 +1869,23 @@ class MessageHandler {
 
             let updatedCount = 0;
             let markHamEntries = [];
+            let messageProjection = {
+                _id: true,
+                uid: true
+            };
+
+            if (updateDate) {
+                messageProjection.envelope = true;
+                messageProjection['mimeTree.header'] = true;
+            }
+
             let cursor = this.database
                 .collection('messages')
                 .find({
                     mailbox: mailboxData._id,
                     uid: messageQuery
                 })
-                .project({
-                    _id: true,
-                    uid: true
-                });
+                .project(messageProjection);
 
             let publishMarkHamEntries = () => {
                 if (!markHamEntries.length) {
@@ -1927,6 +1971,17 @@ class MessageHandler {
                         return processNext();
                     }
 
+                    let messageUpdates = updates;
+                    if (updateDate) {
+                        messageUpdates = {
+                            ...updates,
+                            $set: {
+                                ...updates.$set,
+                                ...this.getMessageDateUpdate(messageData, updateDate)
+                            }
+                        };
+                    }
+
                     this.database.collection('messages').findOneAndUpdate(
                         {
                             _id: messageData._id,
@@ -1934,7 +1989,7 @@ class MessageHandler {
                             mailbox,
                             uid: messageData.uid
                         },
-                        updates,
+                        messageUpdates,
                         {
                             projection: {
                                 _id: true,

--- a/lib/message-handler.js
+++ b/lib/message-handler.js
@@ -1720,33 +1720,64 @@ class MessageHandler {
         });
     }
 
+    /**
+     * Builds the update fragment that brings every stored representation of the message date in sync
+     *
+     * Header lines are rebuilt from `mimeTree.header`, so changing the Date line also changes the size of
+     * the resulting RFC822 message. The stored size is what IMAP reports as RFC822.SIZE and what quota
+     * accounting is based on, so the caller must apply `sizeDelta` to the user quota as well.
+     *
+     * @param {Object} message Message document, should include `mimeTree.header`, `envelope` and `size`
+     * @param {Date} sendTime New message date
+     * @returns {Object} `{ update, sizeDelta }` where `update` is a $set fragment and `sizeDelta` is the
+     *                   change of the stored message size in bytes
+     */
     getMessageDateUpdate(message, sendTime) {
         let formattedDate = tools.formatDateHeader(sendTime);
-        let headers = [].concat((message.mimeTree && message.mimeTree.header) || []);
+        let dateHeader = `Date: ${formattedDate}`;
         let headerFound = false;
+        let sizeDelta = 0;
 
-        headers = headers.map(header => {
+        // map() returns a fresh array, the stored header list is not mutated
+        let headers = ((message.mimeTree && message.mimeTree.header) || []).map(header => {
             if (!/^date\s*:/i.test(header)) {
                 return header;
             }
 
             headerFound = true;
-            return `Date: ${formattedDate}`;
+            sizeDelta += Buffer.byteLength(dateHeader, 'binary') - Buffer.byteLength(header, 'binary');
+            return dateHeader;
         });
 
         if (!headerFound) {
-            headers.push(`Date: ${formattedDate}`);
+            // header lines are joined with CRLF when the message is rebuilt
+            sizeDelta += Buffer.byteLength(dateHeader, 'binary') + 2;
+            headers.push(dateHeader);
         }
 
-        let envelope = [].concat(message.envelope || []);
-        envelope[0] = formattedDate;
-
-        return {
+        let update = {
             hdate: sendTime,
             'mimeTree.header': headers,
-            'mimeTree.parsedHeader.date': sendTime,
-            envelope
+            // parsed headers store the raw header value, not a Date object
+            'mimeTree.parsedHeader.date': formattedDate
         };
+
+        // the cached ENVELOPE response starts with the date value. Only rewrite it if the caller actually
+        // loaded the envelope, replacing an unloaded one would leave the message with a 1 element ENVELOPE
+        if (Array.isArray(message.envelope) && message.envelope.length) {
+            let envelope = [].concat(message.envelope);
+            envelope[0] = formattedDate;
+            update.envelope = envelope;
+        }
+
+        if (typeof message.size === 'number' && sizeDelta) {
+            update.size = message.size + sizeDelta;
+        } else {
+            // without a known starting size we can not keep the stored size correct, so leave quota alone as well
+            sizeDelta = 0;
+        }
+
+        return { update, sizeDelta };
     }
 
     _update(user, mailbox, messageQuery, changes, callback) {
@@ -1758,6 +1789,14 @@ class MessageHandler {
         let markHam = changes && (changes.markHam === true || changes.flagged === true);
 
         let notifyEntries = [];
+
+        if (changes && 'date' in changes) {
+            // resolved before the change loop, as an invalid value must not half apply the update
+            updateDate = changes.date instanceof Date ? changes.date : new Date(changes.date);
+            if (updateDate.toString() === 'Invalid Date') {
+                return setImmediate(() => callback(new Error('Invalid date value')));
+            }
+        }
 
         Object.keys(changes || {}).forEach(key => {
             switch (key) {
@@ -1821,9 +1860,7 @@ class MessageHandler {
                     break;
 
                 case 'date':
-                    updateDate = changes.date;
-                    updates.$set.hdate = changes.date;
-                    updates.$set['mimeTree.parsedHeader.date'] = changes.date;
+                    // the actual fields are resolved per message in getMessageDateUpdate
                     update = true;
                     break;
             }
@@ -1868,6 +1905,7 @@ class MessageHandler {
             }
 
             let updatedCount = 0;
+            let sizeDelta = 0;
             let markHamEntries = [];
             let messageProjection = {
                 _id: true,
@@ -1876,6 +1914,7 @@ class MessageHandler {
 
             if (updateDate) {
                 messageProjection.envelope = true;
+                messageProjection.size = true;
                 messageProjection['mimeTree.header'] = true;
             }
 
@@ -1929,7 +1968,24 @@ class MessageHandler {
                     if (err) {
                         return callback(err);
                     }
-                    return callback(null, updatedCount);
+
+                    if (!sizeDelta) {
+                        return callback(null, updatedCount);
+                    }
+
+                    // rewriting the Date header changed the size of the stored messages
+                    this.updateQuotaAsync(user, { storageUsed: sizeDelta, mailbox: mailboxData._id, mailboxPath: mailboxData.path }, {})
+                        .catch(err => {
+                            this.loggelf({
+                                short_message: '[QUOTAFAIL] Failed to adjust storageUsed after a message date update',
+                                _mail_action: 'quota',
+                                _user: user.toString(),
+                                _mailbox: mailboxData._id.toString(),
+                                _inc: sizeDelta,
+                                _error: err.message
+                            });
+                        })
+                        .finally(() => callback(null, updatedCount));
                 };
 
                 flushUpdates(next);
@@ -1972,12 +2028,15 @@ class MessageHandler {
                     }
 
                     let messageUpdates = updates;
+                    let messageSizeDelta = 0;
                     if (updateDate) {
+                        let dateUpdate = this.getMessageDateUpdate(messageData, updateDate);
+                        messageSizeDelta = dateUpdate.sizeDelta;
                         messageUpdates = {
                             ...updates,
                             $set: {
                                 ...updates.$set,
-                                ...this.getMessageDateUpdate(messageData, updateDate)
+                                ...dateUpdate.update
                             }
                         };
                     }
@@ -2010,15 +2069,26 @@ class MessageHandler {
 
                             let messageData = item.value;
                             updatedCount++;
+                            sizeDelta += messageSizeDelta;
 
-                            notifyEntries.push({
+                            let notifyEntry = {
                                 command: 'FETCH',
                                 uid: messageData.uid,
                                 flags: messageData.flags,
                                 thread: messageData.thread,
                                 message: messageData._id,
                                 unseenChange: 'seen' in changes
-                            });
+                            };
+
+                            if (updateDate) {
+                                // carried over to the search index, which otherwise only tracks flag changes
+                                notifyEntry.hdate = updateDate;
+                                if (typeof messageUpdates.$set.size === 'number') {
+                                    notifyEntry.size = messageUpdates.$set.size;
+                                }
+                            }
+
+                            notifyEntries.push(notifyEntry);
 
                             markMessageHam(messageData);
 

--- a/lib/schemas/request/general-schemas.js
+++ b/lib/schemas/request/general-schemas.js
@@ -12,6 +12,7 @@ const wildcardAddress = Joi.string()
 const addressEmailOrWildcard = Joi.alternatives().try(addressEmail.optional(), wildcardAddress).description('E-mail Address or wildcard address');
 const addressId = Joi.string().hex().lowercase().length(24).required().description('ID of the Address');
 const filterId = Joi.string().hex().lowercase().length(24).required().description('Filters unique ID');
+const queueId = Joi.string().hex().lowercase().min(18).max(24).required().description('Outbound queue ID of the message');
 
 module.exports = {
     userId,
@@ -20,5 +21,6 @@ module.exports = {
     addressEmail,
     addressEmailOrWildcard,
     addressId,
-    filterId
+    filterId,
+    queueId
 };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -659,6 +659,16 @@ function getEnabled2fa(enabled2fa) {
     return list;
 }
 
+/**
+ * Formats a date as a RFC 5322 Date header value
+ *
+ * @param {Date} date Date to format
+ * @returns {String} Date value for the Date header, eg. "Tue, 25 Aug 2026 12:00:00 +0000"
+ */
+function formatDateHeader(date) {
+    return date.toUTCString().replace(/GMT/, '+0000');
+}
+
 function roundTime(seconds) {
     let days = Math.floor(seconds / (24 * 3600));
     if (days) {
@@ -881,6 +891,7 @@ module.exports = {
     prepareArmoredPubKey,
     getPGPUserId,
     formatFingerprint,
+    formatDateHeader,
     getUserEncryptionKey,
     getEnabled2fa,
     roundTime,

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -702,60 +702,61 @@ describe('API tests', function () {
                 .expect(200);
             expect(submitResponse.body.queueId).to.exist;
 
-            const sentMessageDataResponse = await server.get(
-                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
-            );
+            const messageUrl = `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`;
+            const outboundUrl = `/users/${userId}/outbound/${submitResponse.body.queueId}`;
+
+            const sentMessageDataResponse = await server.get(messageUrl).expect(200);
 
             expect(sentMessageDataResponse.body.outbound[0].queueId).to.equal(submitResponse.body.queueId);
 
             let updatedSendTime = new Date(Date.now() + 12 * 3600 * 1000).toISOString();
-            const updateResponse = await server
-                .put(`/users/${userId}/outbound/${submitResponse.body.queueId}`)
-                .send({ sendTime: updatedSendTime })
-                .expect(200);
+            const updateResponse = await server.put(outboundUrl).send({ sendTime: updatedSendTime }).expect(200);
             expect(updateResponse.body.success).to.be.true;
             expect(updateResponse.body.queueId).to.equal(submitResponse.body.queueId);
             expect(updateResponse.body.updated).to.equal(6);
 
-            const updatedMessageDataResponse = await server.get(
-                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
-            );
+            const updatedMessageDataResponse = await server.get(messageUrl).expect(200);
             expect(updatedMessageDataResponse.body.outbound[0].entries).to.have.length(6);
             for (let entry of updatedMessageDataResponse.body.outbound[0].entries) {
                 expect(new Date(entry.queued).getTime()).to.equal(new Date(updatedSendTime).getTime());
             }
 
-            const postponeResponse = await server
-                .put(`/users/${userId}/outbound/${submitResponse.body.queueId}`)
-                .send({ sendTime })
-                .expect(200);
+            const postponeResponse = await server.put(outboundUrl).send({ sendTime }).expect(200);
             expect(postponeResponse.body.success).to.be.true;
             expect(postponeResponse.body.updated).to.equal(6);
 
-            const postponedMessageDataResponse = await server.get(
-                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
-            );
+            const postponedMessageDataResponse = await server.get(messageUrl).expect(200);
             for (let entry of postponedMessageDataResponse.body.outbound[0].entries) {
                 expect(new Date(entry.queued).getTime()).to.equal(new Date(sendTime).getTime());
             }
 
-            let sendNow = new Date().toISOString();
-            const sendNowResponse = await server
-                .put(`/users/${userId}/outbound/${submitResponse.body.queueId}`)
-                .send({ sendTime: sendNow })
-                .expect(200);
+            // delivery times in the past are replaced with the current time
+            let sendNow = new Date(Date.now() - 3600 * 1000).toISOString();
+            const sendNowResponse = await server.put(outboundUrl).send({ sendTime: sendNow }).expect(200);
             expect(sendNowResponse.body.success).to.be.true;
             expect(sendNowResponse.body.updated).to.equal(6);
+            expect(new Date(sendNowResponse.body.sendTime).getTime()).to.be.greaterThan(new Date(sendNow).getTime());
 
-            const sendNowMessageDataResponse = await server.get(
-                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
-            );
+            const sendNowMessageDataResponse = await server.get(messageUrl).expect(200);
             for (let entry of sendNowMessageDataResponse.body.outbound[0].entries) {
-                expect(new Date(entry.queued).getTime()).to.equal(new Date(sendNow).getTime());
+                expect(new Date(entry.queued).getTime()).to.equal(new Date(sendNowResponse.body.sendTime).getTime());
             }
 
-            const deleteResponse = await server.delete(`/users/${userId}/outbound/${submitResponse.body.queueId}`).expect(200);
+            // updating the same delivery time again still counts the matching queue entries
+            const repeatResponse = await server.put(outboundUrl).send({ sendTime: sendNowResponse.body.sendTime }).expect(200);
+            expect(repeatResponse.body.updated).to.equal(6);
+
+            const deleteResponse = await server.delete(outboundUrl).expect(200);
             expect(deleteResponse.body.deleted).to.equal(6);
+        });
+
+        it('should PUT /users/{user}/outbound/{queueId} expect failure / unknown queue id', async () => {
+            const updateResponse = await server
+                .put(`/users/${userId}/outbound/ffffffffffffffffff`)
+                .send({ sendTime: new Date(Date.now() + 3600 * 1000).toISOString() })
+                .expect(404);
+            expect(updateResponse.body.success).to.be.false;
+            expect(updateResponse.body.code).to.equal('NoSuchQueueEntry');
         });
 
         it('should POST /users/{user}/mailboxes/{mailbox}/messages/{message}/submit expect failure / should create a draft message and fail submit', async () => {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -708,6 +708,52 @@ describe('API tests', function () {
 
             expect(sentMessageDataResponse.body.outbound[0].queueId).to.equal(submitResponse.body.queueId);
 
+            let updatedSendTime = new Date(Date.now() + 12 * 3600 * 1000).toISOString();
+            const updateResponse = await server
+                .put(`/users/${userId}/outbound/${submitResponse.body.queueId}`)
+                .send({ sendTime: updatedSendTime })
+                .expect(200);
+            expect(updateResponse.body.success).to.be.true;
+            expect(updateResponse.body.queueId).to.equal(submitResponse.body.queueId);
+            expect(updateResponse.body.updated).to.equal(6);
+
+            const updatedMessageDataResponse = await server.get(
+                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
+            );
+            expect(updatedMessageDataResponse.body.outbound[0].entries).to.have.length(6);
+            for (let entry of updatedMessageDataResponse.body.outbound[0].entries) {
+                expect(new Date(entry.queued).getTime()).to.equal(new Date(updatedSendTime).getTime());
+            }
+
+            const postponeResponse = await server
+                .put(`/users/${userId}/outbound/${submitResponse.body.queueId}`)
+                .send({ sendTime })
+                .expect(200);
+            expect(postponeResponse.body.success).to.be.true;
+            expect(postponeResponse.body.updated).to.equal(6);
+
+            const postponedMessageDataResponse = await server.get(
+                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
+            );
+            for (let entry of postponedMessageDataResponse.body.outbound[0].entries) {
+                expect(new Date(entry.queued).getTime()).to.equal(new Date(sendTime).getTime());
+            }
+
+            let sendNow = new Date().toISOString();
+            const sendNowResponse = await server
+                .put(`/users/${userId}/outbound/${submitResponse.body.queueId}`)
+                .send({ sendTime: sendNow })
+                .expect(200);
+            expect(sendNowResponse.body.success).to.be.true;
+            expect(sendNowResponse.body.updated).to.equal(6);
+
+            const sendNowMessageDataResponse = await server.get(
+                `/users/${userId}/mailboxes/${submitResponse.body.message.mailbox}/messages/${submitResponse.body.message.id}`
+            );
+            for (let entry of sendNowMessageDataResponse.body.outbound[0].entries) {
+                expect(new Date(entry.queued).getTime()).to.equal(new Date(sendNow).getTime());
+            }
+
             const deleteResponse = await server.delete(`/users/${userId}/outbound/${submitResponse.body.queueId}`).expect(200);
             expect(deleteResponse.body.deleted).to.equal(6);
         });

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -715,7 +715,9 @@ describe('API tests', function () {
             expect(updateResponse.body.success).to.be.true;
             expect(updateResponse.body.queueId).to.equal(submitResponse.body.queueId);
             expect(updateResponse.body.updated).to.equal(6);
-            expect(updateResponse.body).not.to.have.property('submitted');
+            expect(updateResponse.body.dateUpdated).to.be.true;
+            // the copy in the Sent Mail folder was re-dated as well
+            expect(updateResponse.body.storedUpdated).to.equal(1);
 
             const updatedMessageDataResponse = await server.get(messageUrl).expect(200);
             expect(new Date(updatedMessageDataResponse.body.date).getTime()).to.equal(new Date(updatedSendTime).getTime());
@@ -729,6 +731,9 @@ describe('API tests', function () {
             const updatedSourceDate = updatedMessageSource.match(/^Date:\s*(.+)$/im);
             expect(updatedSourceDate).to.exist;
             expect(new Date(updatedSourceDate[1]).getTime()).to.equal(Math.floor(new Date(updatedSendTime).getTime() / 1000) * 1000);
+
+            // the stored size is what IMAP reports as RFC822.SIZE, it has to match the rebuilt message
+            expect(updatedMessageDataResponse.body.size).to.equal(Buffer.byteLength(updatedMessageSource, 'binary'));
 
             const postponeResponse = await server.put(outboundUrl).send({ sendTime }).expect(200);
             expect(postponeResponse.body.success).to.be.true;
@@ -768,6 +773,69 @@ describe('API tests', function () {
                 .expect(404);
             expect(updateResponse.body.success).to.be.false;
             expect(updateResponse.body.code).to.equal('NoSuchQueueEntry');
+            expect(updateResponse.body.error).to.be.a('string').and.not.empty;
+        });
+
+        it('should PUT /users/{user}/outbound/{queueId} expect failure / delivery time past the queue expiry', async () => {
+            const message = {
+                from: { name: 'test tester1', address: 'testuser1@example.com' },
+                to: [{ name: 'test tester2', address: 'testuser2@example.com' }],
+                draft: true,
+                subject: 'expiring send time',
+                text: 'Hello hello world!'
+            };
+
+            const response = await server.post(`/users/${userId}/mailboxes/${inbox}/messages`).send(message).expect(200);
+            const submitResponse = await server.post(`/users/${userId}/mailboxes/${inbox}/messages/${response.body.message.id}/submit`).send({}).expect(200);
+
+            const outboundUrl = `/users/${userId}/outbound/${submitResponse.body.queueId}`;
+
+            // the MTA drops queue entries that are older than consts.MAX_QUEUE_TIME without a bounce
+            const tooLate = new Date(Date.now() + 31 * 24 * 3600 * 1000).toISOString();
+            const updateResponse = await server.put(outboundUrl).send({ sendTime: tooLate }).expect(400);
+            expect(updateResponse.body.success).to.be.false;
+            expect(updateResponse.body.code).to.equal('SendTimeTooLate');
+            expect(updateResponse.body.error).to.be.a('string').and.not.empty;
+
+            await server.delete(outboundUrl).expect(200);
+        });
+
+        it('should PUT /users/{user}/outbound/{queueId} expect failure / queue entry of another user', async () => {
+            const otherUserResponse = await server
+                .post('/users')
+                .send({
+                    username: 'outboundstranger',
+                    password: 'secretvalue',
+                    address: 'outboundstranger@example.com',
+                    name: 'outbound stranger'
+                })
+                .expect(200);
+            const otherUserId = otherUserResponse.body.id;
+
+            const message = {
+                from: { name: 'test tester1', address: 'testuser1@example.com' },
+                to: [{ name: 'test tester2', address: 'testuser2@example.com' }],
+                draft: true,
+                subject: 'not yours',
+                text: 'Hello hello world!'
+            };
+
+            const response = await server.post(`/users/${userId}/mailboxes/${inbox}/messages`).send(message).expect(200);
+            const submitResponse = await server
+                .post(`/users/${userId}/mailboxes/${inbox}/messages/${response.body.message.id}/submit`)
+                .send({ sendTime: new Date(Date.now() + 24 * 3600 * 1000).toISOString() })
+                .expect(200);
+
+            const updateResponse = await server
+                .put(`/users/${otherUserId}/outbound/${submitResponse.body.queueId}`)
+                .send({ sendTime: new Date(Date.now() + 3600 * 1000).toISOString() })
+                .expect(403);
+            expect(updateResponse.body.success).to.be.false;
+            expect(updateResponse.body.code).to.equal('NotEnoughPrivileges');
+            expect(updateResponse.body.error).to.be.a('string').and.not.empty;
+
+            await server.delete(`/users/${userId}/outbound/${submitResponse.body.queueId}`).expect(200);
+            await server.delete(`/users/${otherUserId}`).expect(200);
         });
 
         it('should POST /users/{user}/mailboxes/{mailbox}/messages/{message}/submit expect failure / should create a draft message and fail submit', async () => {

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -708,24 +708,34 @@ describe('API tests', function () {
             const sentMessageDataResponse = await server.get(messageUrl).expect(200);
 
             expect(sentMessageDataResponse.body.outbound[0].queueId).to.equal(submitResponse.body.queueId);
+            expect(new Date(sentMessageDataResponse.body.date).getTime()).to.equal(new Date(sendTime).getTime());
 
             let updatedSendTime = new Date(Date.now() + 12 * 3600 * 1000).toISOString();
             const updateResponse = await server.put(outboundUrl).send({ sendTime: updatedSendTime }).expect(200);
             expect(updateResponse.body.success).to.be.true;
             expect(updateResponse.body.queueId).to.equal(submitResponse.body.queueId);
             expect(updateResponse.body.updated).to.equal(6);
+            expect(updateResponse.body).not.to.have.property('submitted');
 
             const updatedMessageDataResponse = await server.get(messageUrl).expect(200);
+            expect(new Date(updatedMessageDataResponse.body.date).getTime()).to.equal(new Date(updatedSendTime).getTime());
             expect(updatedMessageDataResponse.body.outbound[0].entries).to.have.length(6);
             for (let entry of updatedMessageDataResponse.body.outbound[0].entries) {
                 expect(new Date(entry.queued).getTime()).to.equal(new Date(updatedSendTime).getTime());
             }
+
+            const updatedMessageSourceResponse = await server.get(`${messageUrl}/message.eml`).expect(200);
+            const updatedMessageSource = updatedMessageSourceResponse.text || updatedMessageSourceResponse.body.toString();
+            const updatedSourceDate = updatedMessageSource.match(/^Date:\s*(.+)$/im);
+            expect(updatedSourceDate).to.exist;
+            expect(new Date(updatedSourceDate[1]).getTime()).to.equal(Math.floor(new Date(updatedSendTime).getTime() / 1000) * 1000);
 
             const postponeResponse = await server.put(outboundUrl).send({ sendTime }).expect(200);
             expect(postponeResponse.body.success).to.be.true;
             expect(postponeResponse.body.updated).to.equal(6);
 
             const postponedMessageDataResponse = await server.get(messageUrl).expect(200);
+            expect(new Date(postponedMessageDataResponse.body.date).getTime()).to.equal(new Date(sendTime).getTime());
             for (let entry of postponedMessageDataResponse.body.outbound[0].entries) {
                 expect(new Date(entry.queued).getTime()).to.equal(new Date(sendTime).getTime());
             }
@@ -738,6 +748,7 @@ describe('API tests', function () {
             expect(new Date(sendNowResponse.body.sendTime).getTime()).to.be.greaterThan(new Date(sendNow).getTime());
 
             const sendNowMessageDataResponse = await server.get(messageUrl).expect(200);
+            expect(new Date(sendNowMessageDataResponse.body.date).getTime()).to.equal(new Date(sendNowResponse.body.sendTime).getTime());
             for (let entry of sendNowMessageDataResponse.body.outbound[0].entries) {
                 expect(new Date(entry.queued).getTime()).to.equal(new Date(sendNowResponse.body.sendTime).getTime());
             }

--- a/test/maildropper-test.js
+++ b/test/maildropper-test.js
@@ -4,6 +4,7 @@
 
 const chai = require('chai');
 const Maildropper = require('../lib/maildropper');
+const consts = require('../lib/consts');
 
 const expect = chai.expect;
 
@@ -18,6 +19,21 @@ describe('Maildropper', function () {
 
         return new Maildropper({
             db: {
+                // stored messages that reference a queue ID, used as the ownership fallback
+                database: {
+                    collection(name) {
+                        if (name === 'messages') {
+                            return {
+                                findOne: async query => {
+                                    handlers.onMessageLookup && handlers.onMessageLookup(query);
+                                    return handlers.referencedBy || null;
+                                }
+                            };
+                        }
+
+                        throw new Error(`Unexpected collection: ${name}`);
+                    }
+                },
                 senderDb: {
                     collection(name) {
                         if (name === 'mail.files') {
@@ -31,7 +47,12 @@ describe('Maildropper', function () {
                         }
 
                         if (name === 'zone-queue') {
-                            return { updateMany: handlers.updateMany || notCalled('updateMany') };
+                            return {
+                                updateMany: handlers.updateMany || notCalled('updateMany'),
+                                deleteMany: handlers.deleteMany || notCalled('deleteMany'),
+                                // by default every entry that was matched is still the whole queue
+                                countDocuments: handlers.countDocuments || (async () => handlers.pending || 0)
+                            };
                         }
 
                         throw new Error(`Unexpected collection: ${name}`);
@@ -40,214 +61,356 @@ describe('Maildropper', function () {
             },
             collection: 'zone-queue',
             gfs: 'mail',
-            gridstore: {}
+            gridstore: handlers.gridstore || {}
         });
     };
 
     // GridFS entry of a queued message, `data` is the stored envelope
     const queueFileFor = data => ({
         _id: 'gridfs-id',
+        uploadDate: new Date('2026-08-24T09:00:00.000Z'),
         metadata: { data }
     });
 
     const submittedQueueFile = headers => queueFileFor({ userId: 'user-id', reason: 'submit', headers });
 
-    it('updates all unlocked entries with the requested delivery time', async function () {
-        const sendTime = new Date('2026-08-25T12:00:00.000Z');
-        let lookupQuery;
-        let updateQuery;
-        let updateValue;
-        const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
-            onFindOne: query => {
-                lookupQuery = query;
-            },
-            updateMany: async (query, update) => {
-                updateQuery = query;
-                updateValue = update;
-                return { matchedCount: 2, modifiedCount: 2 };
-            }
+    describe('updateQueueTime', function () {
+        it('updates all unlocked entries with the requested delivery time', async function () {
+            const sendTime = new Date('2026-08-25T12:00:00.000Z');
+            let lookupQuery;
+            let updateQuery;
+            let updateValue;
+            const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+                pending: 2,
+                onFindOne: query => {
+                    lookupQuery = query;
+                },
+                updateMany: async (query, update) => {
+                    updateQuery = query;
+                    updateValue = update;
+                    return { matchedCount: 2, modifiedCount: 2 };
+                }
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+            expect(lookupQuery).to.deep.equal({ filename: 'message queue-id' });
+            expect(updateQuery).to.deep.equal({
+                id: 'queue-id',
+                locked: false
+            });
+            expect(updateValue).to.deep.equal({
+                $set: {
+                    queued: sendTime
+                }
+            });
+            expect(result).to.deep.equal({
+                success: true,
+                queueId: 'queue-id',
+                updated: 2,
+                dateUpdated: false
+            });
         });
 
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+        it('counts matched entries, not modified ones', async function () {
+            // re-sending the same delivery time modifies nothing but is still a successful update
+            const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+                pending: 3,
+                updateMany: async () => ({ matchedCount: 3, modifiedCount: 0 })
+            });
 
-        expect(lookupQuery).to.deep.equal({ filename: 'message queue-id' });
-        expect(updateQuery).to.deep.equal({
-            id: 'queue-id',
-            locked: false
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result.success).to.be.true;
+            expect(result.updated).to.equal(3);
         });
-        expect(updateValue).to.deep.equal({
-            $set: {
-                queued: sendTime
-            }
+
+        it('rejects an update if all queue entries are locked for delivery', async function () {
+            const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+                pending: 2,
+                updateMany: async () => ({ matchedCount: 0, modifiedCount: 0 })
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'QueueEntryLocked',
+                updated: 0,
+                locked: 2
+            });
         });
-        expect(result).to.deep.equal({
-            success: true,
-            queueId: 'queue-id',
-            updated: 2
+
+        it('rejects an update if only some of the queue entries could be rescheduled', async function () {
+            // the locked entries keep the Date header they were queued with, so rewriting the shared
+            // Date header would hand those recipients a Date value from the future
+            const sendTime = new Date('2026-08-25T12:00:00.000Z');
+            const maildropper = createMaildropper(submittedQueueFile([]), {
+                pending: 6,
+                updateMany: async () => ({ matchedCount: 4, modifiedCount: 4 })
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'QueueEntryLocked',
+                updated: 4,
+                locked: 2
+            });
+        });
+
+        it('reports a missing entry if the last queue entry was delivered while updating', async function () {
+            const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+                pending: 0,
+                updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 })
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NoSuchQueueEntry'
+            });
+        });
+
+        it('rejects a delivery time that the queue entry would not survive until', async function () {
+            // the MTA expires queue entries by insertion time and drops these without a bounce
+            const queueFile = queueFileFor({ userId: 'user-id' });
+            // updateMany is not stubbed, so touching the queue would throw
+            const maildropper = createMaildropper(queueFile);
+
+            const sendTime = new Date(queueFile.uploadDate.getTime() + consts.MAX_QUEUE_TIME + 1000);
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+            expect(result.success).to.be.false;
+            expect(result.code).to.equal('SendTimeTooLate');
+            expect(result.maxSendTime.getTime()).to.equal(queueFile.uploadDate.getTime() + consts.MAX_QUEUE_TIME);
+        });
+
+        it('allows a delivery time right at the queue expiry time', async function () {
+            const queueFile = queueFileFor({ userId: 'user-id' });
+            const maildropper = createMaildropper(queueFile, {
+                pending: 1,
+                updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 })
+            });
+
+            const sendTime = new Date(queueFile.uploadDate.getTime() + consts.MAX_QUEUE_TIME);
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+            expect(result.success).to.be.true;
+        });
+
+        it('rejects a queue entry owned by another user', async function () {
+            const maildropper = createMaildropper(queueFileFor({ userId: 'another-user-id' }));
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NotEnoughPrivileges'
+            });
+        });
+
+        it('rejects a queue entry that is not linked to any user', async function () {
+            // system generated messages without an owner must not be modifiable by a user token
+            const maildropper = createMaildropper(queueFileFor({ reason: 'bounce' }));
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NotEnoughPrivileges'
+            });
+        });
+
+        it('accepts an unowned queue entry that one of the user messages references', async function () {
+            // not every producer stamps the owner onto the queue metadata, and entries queued before a
+            // producer was fixed never will. The `outbound` reference is how the user got the queue ID
+            let messageQuery;
+            const maildropper = createMaildropper(queueFileFor({ reason: 'forward' }), {
+                pending: 1,
+                referencedBy: { _id: 'message-id' },
+                onMessageLookup: query => {
+                    messageQuery = query;
+                },
+                updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 })
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(messageQuery).to.deep.equal({ user: 'user-id', outbound: 'queue-id' });
+            expect(result.success).to.be.true;
+        });
+
+        it('does not fall back to the message reference when the entry is owned by another user', async function () {
+            // onMessageLookup is not stubbed to return anything, but the owner mismatch must reject first
+            const maildropper = createMaildropper(queueFileFor({ userId: 'another-user-id' }), {
+                referencedBy: { _id: 'message-id' }
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NotEnoughPrivileges'
+            });
+        });
+
+        it('rejects a queue entry that has no metadata yet', async function () {
+            // metadata is stored after the message itself, so a queue file might not have it yet
+            const maildropper = createMaildropper({ _id: 'gridfs-id' });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NotEnoughPrivileges'
+            });
+        });
+
+        it('returns a missing-entry response when the queue file does not exist', async function () {
+            const maildropper = createMaildropper(false);
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NoSuchQueueEntry'
+            });
+        });
+
+        it('keeps the Date header of a submitted message in sync with the delivery time', async function () {
+            const sendTime = new Date('2026-08-25T12:00:00.000Z');
+            const queueFile = submittedQueueFile([
+                { key: 'from', line: 'From: sender@example.com' },
+                { key: 'date', line: 'Date: Mon, 24 Aug 2026 09:00:00 +0000' }
+            ]);
+            let metaQuery;
+            let metaUpdate;
+            const maildropper = createMaildropper(queueFile, {
+                pending: 1,
+                updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
+                updateOne: async (query, update) => {
+                    metaQuery = query;
+                    metaUpdate = update;
+                    return { matchedCount: 1, modifiedCount: 1 };
+                }
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+            expect(result.success).to.be.true;
+            expect(result.dateUpdated).to.be.true;
+            expect(metaQuery).to.deep.equal({ _id: 'gridfs-id' });
+            expect(metaUpdate.$set['metadata.data.date']).to.equal('Tue, 25 Aug 2026 12:00:00 +0000');
+
+            const headerLines = metaUpdate.$set['metadata.data.headers'];
+            const dateLines = headerLines.filter(line => line.key === 'date');
+            expect(dateLines).to.have.length(1);
+            expect(dateLines[0].line).to.equal('Date: Tue, 25 Aug 2026 12:00:00 +0000');
+            expect(headerLines.some(line => line.key === 'from')).to.be.true;
+        });
+
+        it('adds a Date header to a submitted message that does not have one', async function () {
+            const sendTime = new Date('2026-08-25T12:00:00.000Z');
+            const queueFile = submittedQueueFile([{ key: 'from', line: 'From: sender@example.com' }]);
+            let metaUpdate;
+            const maildropper = createMaildropper(queueFile, {
+                pending: 1,
+                updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
+                updateOne: async (query, update) => {
+                    metaUpdate = update;
+                    return { matchedCount: 1, modifiedCount: 1 };
+                }
+            });
+
+            await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+            const dateLines = metaUpdate.$set['metadata.data.headers'].filter(line => line.key === 'date');
+            expect(dateLines).to.have.length(1);
+            expect(dateLines[0].line).to.equal('Date: Tue, 25 Aug 2026 12:00:00 +0000');
+        });
+
+        it('does not touch the Date header of a forwarded message', async function () {
+            // forwarded messages carry the Date value of the original message and might be signed
+            const queueFile = queueFileFor({
+                userId: 'user-id',
+                reason: 'forward',
+                headers: [{ key: 'date', line: 'Date: Mon, 24 Aug 2026 09:00:00 +0000' }]
+            });
+            // updateOne is not stubbed, so touching the stored headers would throw
+            const maildropper = createMaildropper(queueFile, {
+                pending: 1,
+                updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 })
+            });
+
+            const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+            expect(result.success).to.be.true;
+            // the caller uses this to decide whether the stored copies need to be re-dated as well
+            expect(result.dateUpdated).to.be.false;
         });
     });
 
-    it('counts matched entries, not modified ones', async function () {
-        // re-sending the same delivery time modifies nothing but is still a successful update
-        const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
-            updateMany: async () => ({ matchedCount: 3, modifiedCount: 0 })
+    describe('removeFromQueue', function () {
+        it('does not allow removing a queue entry that is not linked to any user', async function () {
+            const maildropper = createMaildropper(queueFileFor({ reason: 'bounce' }));
+
+            const result = await maildropper.removeFromQueue('queue-id', 'user-id');
+
+            expect(result).to.deep.equal({
+                success: false,
+                code: 'NotEnoughPrivileges'
+            });
         });
 
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+        it('allows the owner to remove an unowned entry that their message references', async function () {
+            const maildropper = createMaildropper(queueFileFor({ reason: 'autoreply' }), {
+                pending: 1,
+                referencedBy: { _id: 'message-id' },
+                deleteMany: async () => ({ deletedCount: 1 })
+            });
 
-        expect(result).to.deep.equal({
-            success: true,
-            queueId: 'queue-id',
-            updated: 3
-        });
-    });
+            const result = await maildropper.removeFromQueue('queue-id', 'user-id');
 
-    it('rejects an update if all queue entries are locked for delivery', async function () {
-        const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
-            updateMany: async () => ({ matchedCount: 0, modifiedCount: 0 })
-        });
-
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
-
-        expect(result).to.deep.equal({
-            success: false,
-            code: 'QueueEntryLocked'
-        });
-    });
-
-    it('rejects a queue entry owned by another user', async function () {
-        const maildropper = createMaildropper(queueFileFor({ userId: 'another-user-id' }));
-
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
-
-        expect(result).to.deep.equal({
-            success: false,
-            code: 'NotEnoughPrivileges'
-        });
-    });
-
-    it('rejects a queue entry that is not linked to any user', async function () {
-        // autoreplies and other generated messages are queued without an owner, these must not be
-        // modifiable by a user token
-        const maildropper = createMaildropper(queueFileFor({ reason: 'autoreply' }));
-
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
-
-        expect(result).to.deep.equal({
-            success: false,
-            code: 'NotEnoughPrivileges'
-        });
-    });
-
-    it('rejects a queue entry that has no metadata yet', async function () {
-        // metadata is stored after the message itself, so a queue file might not have it yet
-        const maildropper = createMaildropper({ _id: 'gridfs-id' });
-
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
-
-        expect(result).to.deep.equal({
-            success: false,
-            code: 'NotEnoughPrivileges'
-        });
-    });
-
-    it('returns a missing-entry response when the queue file does not exist', async function () {
-        const maildropper = createMaildropper(false);
-
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
-
-        expect(result).to.deep.equal({
-            success: false,
-            code: 'NoSuchQueueEntry'
-        });
-    });
-
-    it('keeps the Date header of a submitted message in sync with the delivery time', async function () {
-        const sendTime = new Date('2026-08-25T12:00:00.000Z');
-        const queueFile = submittedQueueFile([
-            { key: 'from', line: 'From: sender@example.com' },
-            { key: 'date', line: 'Date: Mon, 24 Aug 2026 09:00:00 +0000' }
-        ]);
-        let metaQuery;
-        let metaUpdate;
-        const maildropper = createMaildropper(queueFile, {
-            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
-            updateOne: async (query, update) => {
-                metaQuery = query;
-                metaUpdate = update;
-                return { matchedCount: 1, modifiedCount: 1 };
-            }
+            expect(result.success).to.be.true;
+            expect(result.deleted).to.equal(1);
         });
 
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+        it('allows the owner to remove an autoreply that was queued for them', async function () {
+            // autoreplies are queued with the user as the owner, as the queue ID is handed to the user
+            // in the `outbound` array of the message that triggered the autoreply
+            const maildropper = createMaildropper(queueFileFor({ userId: 'user-id', reason: 'autoreply' }), {
+                pending: 1,
+                deleteMany: async () => ({ deletedCount: 1 })
+            });
 
-        expect(result.success).to.be.true;
-        expect(metaQuery).to.deep.equal({ _id: 'gridfs-id' });
-        expect(metaUpdate.$set['metadata.data.date']).to.equal('Tue, 25 Aug 2026 12:00:00 +0000');
+            const result = await maildropper.removeFromQueue('queue-id', 'user-id');
 
-        const headerLines = metaUpdate.$set['metadata.data.headers'];
-        const dateLines = headerLines.filter(line => line.key === 'date');
-        expect(dateLines).to.have.length(1);
-        expect(dateLines[0].line).to.equal('Date: Tue, 25 Aug 2026 12:00:00 +0000');
-        expect(headerLines.some(line => line.key === 'from')).to.be.true;
-    });
-
-    it('marks submitted queue entries in the internal update result', async function () {
-        const maildropper = createMaildropper(submittedQueueFile([]), {
-            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
-            updateOne: async () => ({ matchedCount: 1, modifiedCount: 1 })
+            expect(result).to.deep.equal({
+                success: true,
+                queueId: 'queue-id',
+                deleted: 1
+            });
         });
 
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+        it('drops the stored message once the last queue entry is removed', async function () {
+            let deletedFileId;
+            const maildropper = createMaildropper(queueFileFor({ userId: 'user-id', reason: 'submit' }), {
+                pending: 0,
+                deleteMany: async () => ({ deletedCount: 2 }),
+                gridstore: {
+                    delete: async id => {
+                        deletedFileId = id;
+                    }
+                }
+            });
 
-        expect(result.submitted).to.be.true;
-    });
+            const result = await maildropper.removeFromQueue('queue-id', 'user-id');
 
-    it('adds a Date header to a submitted message that does not have one', async function () {
-        const sendTime = new Date('2026-08-25T12:00:00.000Z');
-        const queueFile = submittedQueueFile([{ key: 'from', line: 'From: sender@example.com' }]);
-        let metaUpdate;
-        const maildropper = createMaildropper(queueFile, {
-            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
-            updateOne: async (query, update) => {
-                metaUpdate = update;
-                return { matchedCount: 1, modifiedCount: 1 };
-            }
-        });
-
-        await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
-
-        const dateLines = metaUpdate.$set['metadata.data.headers'].filter(line => line.key === 'date');
-        expect(dateLines).to.have.length(1);
-        expect(dateLines[0].line).to.equal('Date: Tue, 25 Aug 2026 12:00:00 +0000');
-    });
-
-    it('does not touch the Date header of a forwarded message', async function () {
-        // forwarded messages carry the Date value of the original message and might be signed
-        const queueFile = queueFileFor({
-            userId: 'user-id',
-            reason: 'forward',
-            headers: [{ key: 'date', line: 'Date: Mon, 24 Aug 2026 09:00:00 +0000' }]
-        });
-        // updateOne is not stubbed, so touching the stored headers would throw
-        const maildropper = createMaildropper(queueFile, {
-            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 })
-        });
-
-        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
-
-        expect(result.success).to.be.true;
-        expect(result).not.to.have.property('submitted');
-    });
-
-    it('does not allow removing a queue entry that is not linked to any user', async function () {
-        const maildropper = createMaildropper(queueFileFor({ reason: 'autoreply' }));
-
-        const result = await maildropper.removeFromQueue('queue-id', 'user-id');
-
-        expect(result).to.deep.equal({
-            success: false,
-            code: 'NotEnoughPrivileges'
+            expect(result.deleted).to.equal(2);
+            expect(deletedFileId).to.equal('gridfs-id');
         });
     });
 });

--- a/test/maildropper-test.js
+++ b/test/maildropper-test.js
@@ -8,22 +8,30 @@ const Maildropper = require('../lib/maildropper');
 const expect = chai.expect;
 
 describe('Maildropper', function () {
-    const createMaildropper = (queueFile, updateMany) =>
-        new Maildropper({
+    const notCalled = name => async () => {
+        throw new Error(`${name} should not be called`);
+    };
+
+    // Fake sender database that only knows about a single queued message
+    const createMaildropper = (queueFile, handlers) => {
+        handlers = handlers || {};
+
+        return new Maildropper({
             db: {
                 senderDb: {
                     collection(name) {
                         if (name === 'mail.files') {
                             return {
                                 findOne: async query => {
-                                    expect(query).to.deep.equal({ filename: 'message queue-id' });
+                                    handlers.onFindOne && handlers.onFindOne(query);
                                     return queueFile;
-                                }
+                                },
+                                updateOne: handlers.updateOne || notCalled('updateOne')
                             };
                         }
 
                         if (name === 'zone-queue') {
-                            return { updateMany };
+                            return { updateMany: handlers.updateMany || notCalled('updateMany') };
                         }
 
                         throw new Error(`Unexpected collection: ${name}`);
@@ -34,26 +42,35 @@ describe('Maildropper', function () {
             gfs: 'mail',
             gridstore: {}
         });
+    };
+
+    // GridFS entry of a queued message, `data` is the stored envelope
+    const queueFileFor = data => ({
+        _id: 'gridfs-id',
+        metadata: { data }
+    });
+
+    const submittedQueueFile = headers => queueFileFor({ userId: 'user-id', reason: 'submit', headers });
 
     it('updates all unlocked entries with the requested delivery time', async function () {
         const sendTime = new Date('2026-08-25T12:00:00.000Z');
-        const queueFile = {
-            metadata: {
-                data: {
-                    userId: 'user-id'
-                }
-            }
-        };
+        let lookupQuery;
         let updateQuery;
         let updateValue;
-        const maildropper = createMaildropper(queueFile, async (query, update) => {
-            updateQuery = query;
-            updateValue = update;
-            return { modifiedCount: 2 };
+        const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+            onFindOne: query => {
+                lookupQuery = query;
+            },
+            updateMany: async (query, update) => {
+                updateQuery = query;
+                updateValue = update;
+                return { matchedCount: 2, modifiedCount: 2 };
+            }
         });
 
         const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
 
+        expect(lookupQuery).to.deep.equal({ filename: 'message queue-id' });
         expect(updateQuery).to.deep.equal({
             id: 'queue-id',
             locked: false
@@ -70,23 +87,64 @@ describe('Maildropper', function () {
         });
     });
 
-    it('rejects a queue entry owned by another user', async function () {
-        const queueFile = {
-            metadata: {
-                data: {
-                    userId: 'another-user-id'
-                }
-            }
-        };
-        let updateCalled = false;
-        const maildropper = createMaildropper(queueFile, async () => {
-            updateCalled = true;
-            return { modifiedCount: 1 };
+    it('counts matched entries, not modified ones', async function () {
+        // re-sending the same delivery time modifies nothing but is still a successful update
+        const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+            updateMany: async () => ({ matchedCount: 3, modifiedCount: 0 })
         });
 
         const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
 
-        expect(updateCalled).to.be.false;
+        expect(result).to.deep.equal({
+            success: true,
+            queueId: 'queue-id',
+            updated: 3
+        });
+    });
+
+    it('rejects an update if all queue entries are locked for delivery', async function () {
+        const maildropper = createMaildropper(queueFileFor({ userId: 'user-id' }), {
+            updateMany: async () => ({ matchedCount: 0, modifiedCount: 0 })
+        });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(result).to.deep.equal({
+            success: false,
+            code: 'QueueEntryLocked'
+        });
+    });
+
+    it('rejects a queue entry owned by another user', async function () {
+        const maildropper = createMaildropper(queueFileFor({ userId: 'another-user-id' }));
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(result).to.deep.equal({
+            success: false,
+            code: 'NotEnoughPrivileges'
+        });
+    });
+
+    it('rejects a queue entry that is not linked to any user', async function () {
+        // autoreplies and other generated messages are queued without an owner, these must not be
+        // modifiable by a user token
+        const maildropper = createMaildropper(queueFileFor({ reason: 'autoreply' }));
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(result).to.deep.equal({
+            success: false,
+            code: 'NotEnoughPrivileges'
+        });
+    });
+
+    it('rejects a queue entry that has no metadata yet', async function () {
+        // metadata is stored after the message itself, so a queue file might not have it yet
+        const maildropper = createMaildropper({ _id: 'gridfs-id' });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
         expect(result).to.deep.equal({
             success: false,
             code: 'NotEnoughPrivileges'
@@ -94,18 +152,90 @@ describe('Maildropper', function () {
     });
 
     it('returns a missing-entry response when the queue file does not exist', async function () {
-        let updateCalled = false;
-        const maildropper = createMaildropper(false, async () => {
-            updateCalled = true;
-            return { modifiedCount: 1 };
+        const maildropper = createMaildropper(false);
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(result).to.deep.equal({
+            success: false,
+            code: 'NoSuchQueueEntry'
+        });
+    });
+
+    it('keeps the Date header of a submitted message in sync with the delivery time', async function () {
+        const sendTime = new Date('2026-08-25T12:00:00.000Z');
+        const queueFile = submittedQueueFile([
+            { key: 'from', line: 'From: sender@example.com' },
+            { key: 'date', line: 'Date: Mon, 24 Aug 2026 09:00:00 +0000' }
+        ]);
+        let metaQuery;
+        let metaUpdate;
+        const maildropper = createMaildropper(queueFile, {
+            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
+            updateOne: async (query, update) => {
+                metaQuery = query;
+                metaUpdate = update;
+                return { matchedCount: 1, modifiedCount: 1 };
+            }
+        });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+        expect(result.success).to.be.true;
+        expect(metaQuery).to.deep.equal({ _id: 'gridfs-id' });
+        expect(metaUpdate.$set['metadata.data.date']).to.equal('Tue, 25 Aug 2026 12:00:00 +0000');
+
+        const headerLines = metaUpdate.$set['metadata.data.headers'];
+        const dateLines = headerLines.filter(line => line.key === 'date');
+        expect(dateLines).to.have.length(1);
+        expect(dateLines[0].line).to.equal('Date: Tue, 25 Aug 2026 12:00:00 +0000');
+        expect(headerLines.some(line => line.key === 'from')).to.be.true;
+    });
+
+    it('adds a Date header to a submitted message that does not have one', async function () {
+        const sendTime = new Date('2026-08-25T12:00:00.000Z');
+        const queueFile = submittedQueueFile([{ key: 'from', line: 'From: sender@example.com' }]);
+        let metaUpdate;
+        const maildropper = createMaildropper(queueFile, {
+            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
+            updateOne: async (query, update) => {
+                metaUpdate = update;
+                return { matchedCount: 1, modifiedCount: 1 };
+            }
+        });
+
+        await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+        const dateLines = metaUpdate.$set['metadata.data.headers'].filter(line => line.key === 'date');
+        expect(dateLines).to.have.length(1);
+        expect(dateLines[0].line).to.equal('Date: Tue, 25 Aug 2026 12:00:00 +0000');
+    });
+
+    it('does not touch the Date header of a forwarded message', async function () {
+        // forwarded messages carry the Date value of the original message and might be signed
+        const queueFile = queueFileFor({
+            userId: 'user-id',
+            reason: 'forward',
+            headers: [{ key: 'date', line: 'Date: Mon, 24 Aug 2026 09:00:00 +0000' }]
+        });
+        // updateOne is not stubbed, so touching the stored headers would throw
+        const maildropper = createMaildropper(queueFile, {
+            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 })
         });
 
         const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
 
-        expect(updateCalled).to.be.false;
+        expect(result.success).to.be.true;
+    });
+
+    it('does not allow removing a queue entry that is not linked to any user', async function () {
+        const maildropper = createMaildropper(queueFileFor({ reason: 'autoreply' }));
+
+        const result = await maildropper.removeFromQueue('queue-id', 'user-id');
+
         expect(result).to.deep.equal({
             success: false,
-            code: 'NoSuchQueueEntry'
+            code: 'NotEnoughPrivileges'
         });
     });
 });

--- a/test/maildropper-test.js
+++ b/test/maildropper-test.js
@@ -1,0 +1,111 @@
+/*eslint no-unused-expressions: 0, prefer-arrow-callback: 0 */
+
+'use strict';
+
+const chai = require('chai');
+const Maildropper = require('../lib/maildropper');
+
+const expect = chai.expect;
+
+describe('Maildropper', function () {
+    const createMaildropper = (queueFile, updateMany) =>
+        new Maildropper({
+            db: {
+                senderDb: {
+                    collection(name) {
+                        if (name === 'mail.files') {
+                            return {
+                                findOne: async query => {
+                                    expect(query).to.deep.equal({ filename: 'message queue-id' });
+                                    return queueFile;
+                                }
+                            };
+                        }
+
+                        if (name === 'zone-queue') {
+                            return { updateMany };
+                        }
+
+                        throw new Error(`Unexpected collection: ${name}`);
+                    }
+                }
+            },
+            collection: 'zone-queue',
+            gfs: 'mail',
+            gridstore: {}
+        });
+
+    it('updates all unlocked entries with the requested delivery time', async function () {
+        const sendTime = new Date('2026-08-25T12:00:00.000Z');
+        const queueFile = {
+            metadata: {
+                data: {
+                    userId: 'user-id'
+                }
+            }
+        };
+        let updateQuery;
+        let updateValue;
+        const maildropper = createMaildropper(queueFile, async (query, update) => {
+            updateQuery = query;
+            updateValue = update;
+            return { modifiedCount: 2 };
+        });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', sendTime);
+
+        expect(updateQuery).to.deep.equal({
+            id: 'queue-id',
+            locked: false
+        });
+        expect(updateValue).to.deep.equal({
+            $set: {
+                queued: sendTime
+            }
+        });
+        expect(result).to.deep.equal({
+            success: true,
+            queueId: 'queue-id',
+            updated: 2
+        });
+    });
+
+    it('rejects a queue entry owned by another user', async function () {
+        const queueFile = {
+            metadata: {
+                data: {
+                    userId: 'another-user-id'
+                }
+            }
+        };
+        let updateCalled = false;
+        const maildropper = createMaildropper(queueFile, async () => {
+            updateCalled = true;
+            return { modifiedCount: 1 };
+        });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(updateCalled).to.be.false;
+        expect(result).to.deep.equal({
+            success: false,
+            code: 'NotEnoughPrivileges'
+        });
+    });
+
+    it('returns a missing-entry response when the queue file does not exist', async function () {
+        let updateCalled = false;
+        const maildropper = createMaildropper(false, async () => {
+            updateCalled = true;
+            return { modifiedCount: 1 };
+        });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(updateCalled).to.be.false;
+        expect(result).to.deep.equal({
+            success: false,
+            code: 'NoSuchQueueEntry'
+        });
+    });
+});

--- a/test/maildropper-test.js
+++ b/test/maildropper-test.js
@@ -192,6 +192,17 @@ describe('Maildropper', function () {
         expect(headerLines.some(line => line.key === 'from')).to.be.true;
     });
 
+    it('marks submitted queue entries in the internal update result', async function () {
+        const maildropper = createMaildropper(submittedQueueFile([]), {
+            updateMany: async () => ({ matchedCount: 1, modifiedCount: 1 }),
+            updateOne: async () => ({ matchedCount: 1, modifiedCount: 1 })
+        });
+
+        const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
+
+        expect(result.submitted).to.be.true;
+    });
+
     it('adds a Date header to a submitted message that does not have one', async function () {
         const sendTime = new Date('2026-08-25T12:00:00.000Z');
         const queueFile = submittedQueueFile([{ key: 'from', line: 'From: sender@example.com' }]);
@@ -226,6 +237,7 @@ describe('Maildropper', function () {
         const result = await maildropper.updateQueueTime('queue-id', 'user-id', new Date());
 
         expect(result.success).to.be.true;
+        expect(result).not.to.have.property('submitted');
     });
 
     it('does not allow removing a queue entry that is not linked to any user', async function () {

--- a/test/message-handler-update-test.js
+++ b/test/message-handler-update-test.js
@@ -39,7 +39,7 @@ function loadModulesWithPublishStub(published) {
 }
 
 describe('MessageHandler message updates', function () {
-    function buildHandler(MessageHandler, checkUpdate) {
+    function buildHandler(MessageHandler, checkUpdate, messageOverrides) {
         const user = new ObjectId();
         const mailbox = new ObjectId();
         const message = new ObjectId();
@@ -48,6 +48,7 @@ describe('MessageHandler message updates', function () {
         let nextCalls = 0;
         let notified = [];
         let fires = 0;
+        let quotaUpdates = [];
         let calls = {
             mailboxFinds: 0,
             mailboxUpdates: 0,
@@ -56,6 +57,18 @@ describe('MessageHandler message updates', function () {
 
         let handler = Object.create(MessageHandler.prototype);
         handler.redis = false;
+        handler.loggelf = () => false;
+        handler.users = {
+            collection(name) {
+                expect(name).to.equal('users');
+                return {
+                    findOneAndUpdate(query, update) {
+                        quotaUpdates.push(update.$inc.storageUsed);
+                        return Promise.resolve({ value: { storageUsed: update.$inc.storageUsed } });
+                    }
+                };
+            }
+        };
         handler.settingsHandler = {
             get: () => Promise.resolve(100)
         };
@@ -117,10 +130,12 @@ describe('MessageHandler message updates', function () {
                                                 return callback(null, {
                                                     _id: message,
                                                     uid: 42,
+                                                    size: 1000,
                                                     envelope: ['Mon, 24 Aug 2026 09:00:00 +0000', 'subject'],
                                                     mimeTree: {
-                                                        header: ['From: sender@example.com', 'Date: Mon, 24 Aug 2026 09:00:00 +0000']
-                                                    }
+                                                        header: ['From: sender@example.com', 'Date: Mon, 24 Aug 2026 09:00:00 +0000 (GMT)']
+                                                    },
+                                                    ...messageOverrides
                                                 });
                                             },
                                             close(callback) {
@@ -160,7 +175,7 @@ describe('MessageHandler message updates', function () {
             }
         };
 
-        return { handler, user, mailbox, message, notified, fires: () => fires, calls };
+        return { handler, user, mailbox, message, notified, fires: () => fires, quotaUpdates, calls };
     }
 
     function updateAsync(handler, user, mailbox, changes) {
@@ -203,14 +218,14 @@ describe('MessageHandler message updates', function () {
     it('updates every stored Date representation and notifies mailbox clients', async function () {
         const MessageHandler = require('../lib/message-handler');
         const sendTime = new Date('2026-08-25T12:00:00.000Z');
-        const { handler, user, mailbox, notified, fires, calls } = buildHandler(MessageHandler, update => {
+        const { handler, user, mailbox, notified, fires, quotaUpdates, calls } = buildHandler(MessageHandler, update => {
             expect(update.$set.hdate).to.equal(sendTime);
-            expect(update.$set['mimeTree.parsedHeader.date']).to.equal(sendTime);
-            expect(update.$set['mimeTree.header']).to.deep.equal([
-                'From: sender@example.com',
-                'Date: Tue, 25 Aug 2026 12:00:00 +0000'
-            ]);
+            // parsed headers store the raw header value, not a Date object
+            expect(update.$set['mimeTree.parsedHeader.date']).to.equal('Tue, 25 Aug 2026 12:00:00 +0000');
+            expect(update.$set['mimeTree.header']).to.deep.equal(['From: sender@example.com', 'Date: Tue, 25 Aug 2026 12:00:00 +0000']);
             expect(update.$set.envelope).to.deep.equal(['Tue, 25 Aug 2026 12:00:00 +0000', 'subject']);
+            // the replaced Date line is 6 bytes shorter than the stored one
+            expect(update.$set.size).to.equal(994);
             expect(update.$set.modseq).to.equal(7);
         });
 
@@ -224,7 +239,63 @@ describe('MessageHandler message updates', function () {
         expect(notified).to.have.lengthOf(1);
         expect(notified[0].command).to.equal('FETCH');
         expect(notified[0].uid).to.equal(42);
+        // carried over to the search index, which otherwise only tracks flag changes
+        expect(notified[0].hdate).to.equal(sendTime);
         expect(fires()).to.equal(1);
+        // the stored message got smaller, so the quota must follow
+        expect(quotaUpdates).to.deep.equal([-6]);
+    });
+
+    it('adds a Date header to a message that does not have one', async function () {
+        const MessageHandler = require('../lib/message-handler');
+        const sendTime = new Date('2026-08-25T12:00:00.000Z');
+        const { handler, user, mailbox, quotaUpdates } = buildHandler(
+            MessageHandler,
+            update => {
+                expect(update.$set['mimeTree.header']).to.deep.equal(['From: sender@example.com', 'Date: Tue, 25 Aug 2026 12:00:00 +0000']);
+                // the added header line plus the CRLF that joins it to the previous line
+                expect(update.$set.size).to.equal(1039);
+            },
+            { mimeTree: { header: ['From: sender@example.com'] } }
+        );
+
+        let updated = await updateAsync(handler, user, mailbox, { date: sendTime });
+
+        expect(updated).to.equal(1);
+        expect(quotaUpdates).to.deep.equal([39]);
+    });
+
+    it('rejects an invalid date without applying a partial update', async function () {
+        const MessageHandler = require('../lib/message-handler');
+        const { handler, user, mailbox, calls } = buildHandler(MessageHandler);
+
+        let err;
+        try {
+            await updateAsync(handler, user, mailbox, { date: 'not a date' });
+        } catch (e) {
+            err = e;
+        }
+
+        expect(err).to.exist;
+        expect(err.message).to.equal('Invalid date value');
+        expect(calls.mailboxUpdates).to.equal(0);
+        expect(calls.messageUpdates).to.equal(0);
+    });
+
+    it('leaves the quota alone when the message has no stored size', async function () {
+        const MessageHandler = require('../lib/message-handler');
+        const { handler, user, mailbox, quotaUpdates } = buildHandler(
+            MessageHandler,
+            update => {
+                expect(update.$set).not.to.have.property('size');
+            },
+            { size: undefined }
+        );
+
+        let updated = await updateAsync(handler, user, mailbox, { date: new Date('2026-08-25T12:00:00.000Z') });
+
+        expect(updated).to.equal(1);
+        expect(quotaUpdates).to.deep.equal([]);
     });
 
     it('publishes marked.ham when markHam=true is the only requested action', async function () {

--- a/test/message-handler-update-test.js
+++ b/test/message-handler-update-test.js
@@ -39,7 +39,7 @@ function loadModulesWithPublishStub(published) {
 }
 
 describe('MessageHandler message updates', function () {
-    function buildHandler(MessageHandler) {
+    function buildHandler(MessageHandler, checkUpdate) {
         const user = new ObjectId();
         const mailbox = new ObjectId();
         const message = new ObjectId();
@@ -47,6 +47,7 @@ describe('MessageHandler message updates', function () {
 
         let nextCalls = 0;
         let notified = [];
+        let fires = 0;
         let calls = {
             mailboxFinds: 0,
             mailboxUpdates: 0,
@@ -63,7 +64,9 @@ describe('MessageHandler message updates', function () {
                 notified.push(...entries);
                 return callback();
             },
-            fire() {}
+            fire() {
+                fires++;
+            }
         };
         handler.database = {
             collection(name) {
@@ -113,7 +116,11 @@ describe('MessageHandler message updates', function () {
                                                 }
                                                 return callback(null, {
                                                     _id: message,
-                                                    uid: 42
+                                                    uid: 42,
+                                                    envelope: ['Mon, 24 Aug 2026 09:00:00 +0000', 'subject'],
+                                                    mimeTree: {
+                                                        header: ['From: sender@example.com', 'Date: Mon, 24 Aug 2026 09:00:00 +0000']
+                                                    }
                                                 });
                                             },
                                             close(callback) {
@@ -128,9 +135,13 @@ describe('MessageHandler message updates', function () {
                                 expect(query._id.toString()).to.equal(message.toString());
                                 expect(query.mailbox.toString()).to.equal(mailbox.toString());
                                 expect(query.uid).to.equal(42);
-                                expect(update.$set.flagged).to.be.true;
-                                expect(update.$set.modseq).to.equal(7);
-                                expect(update.$addToSet.flags.$each).to.deep.equal(['\\Flagged']);
+                                if (checkUpdate) {
+                                    checkUpdate(update);
+                                } else {
+                                    expect(update.$set.flagged).to.be.true;
+                                    expect(update.$set.modseq).to.equal(7);
+                                    expect(update.$addToSet.flags.$each).to.deep.equal(['\\Flagged']);
+                                }
 
                                 return callback(null, {
                                     value: {
@@ -149,7 +160,7 @@ describe('MessageHandler message updates', function () {
             }
         };
 
-        return { handler, user, mailbox, message, notified, calls };
+        return { handler, user, mailbox, message, notified, fires: () => fires, calls };
     }
 
     function updateAsync(handler, user, mailbox, changes) {
@@ -187,6 +198,33 @@ describe('MessageHandler message updates', function () {
         } finally {
             restore();
         }
+    });
+
+    it('updates every stored Date representation and notifies mailbox clients', async function () {
+        const MessageHandler = require('../lib/message-handler');
+        const sendTime = new Date('2026-08-25T12:00:00.000Z');
+        const { handler, user, mailbox, notified, fires, calls } = buildHandler(MessageHandler, update => {
+            expect(update.$set.hdate).to.equal(sendTime);
+            expect(update.$set['mimeTree.parsedHeader.date']).to.equal(sendTime);
+            expect(update.$set['mimeTree.header']).to.deep.equal([
+                'From: sender@example.com',
+                'Date: Tue, 25 Aug 2026 12:00:00 +0000'
+            ]);
+            expect(update.$set.envelope).to.deep.equal(['Tue, 25 Aug 2026 12:00:00 +0000', 'subject']);
+            expect(update.$set.modseq).to.equal(7);
+        });
+
+        let updated = await updateAsync(handler, user, mailbox, {
+            date: sendTime
+        });
+
+        expect(updated).to.equal(1);
+        expect(calls.mailboxUpdates).to.equal(1);
+        expect(calls.messageUpdates).to.equal(1);
+        expect(notified).to.have.lengthOf(1);
+        expect(notified[0].command).to.equal('FETCH');
+        expect(notified[0].uid).to.equal(42);
+        expect(fires()).to.equal(1);
     });
 
     it('publishes marked.ham when markHam=true is the only requested action', async function () {


### PR DESCRIPTION
Adds `PUT /users/{user}/outbound/{queueId}` for changing the delivery time of an outbound message that is still queued. Delivery times in the past are replaced with the current time, and times past the queue expiry are rejected.

For a message submitted by the user the Date header is kept in sync with the new delivery time, in the queued headers and in every stored representation of the message. Forwards and autoreplies are rescheduled but keep the Date value of the original message, and the response reports which of the two happened.

### Notes

- All remaining queue entries of a message have to be reschedulable. The Date header is shared by every recipient, so rescheduling only the unlocked entries would deliver the locked ones with a Date value from the future. The request fails with `QueueEntryLocked` in that case, reporting how many entries are being delivered.
- Rewriting the Date header changes the size of the stored message, so `size` is recomputed and the difference is applied to the user quota. IMAP serves `RFC822.SIZE` from the stored value but rebuilds the `BODY[]` literal from the mime tree, so these have to agree.
- Ownership of a queue entry is taken from the queue metadata, and falls back to the `outbound` reference on the user's own messages. Not every producer stamps the owner (autoreplies did not, `haraka-plugin-wildduck` still does not for forwards) and entries queued before a producer is fixed never will, but the `outbound` reference is how the user got the queue ID in the first place. Entries owned by another user are rejected either way.
- `sender.maxQueueTime` is new in `config/sender.toml` and must match the `maxQueueTime` value of ZoneMTA. The MTA expires queue entries by insertion time and drops them without a bounce, so a delivery time past that point would silently lose the message.
- The regenerated OpenAPI docs also pick up `includeHasDrafts`, `collapseThreads` and `markHam`, which landed on master without a regeneration.
