### PR TITLE
fix(api-search): ZMS-94: keep $text queries plannable inside OR branches

### DIFF
--- a/lib/prepare-search-filter.js
+++ b/lib/prepare-search-filter.js
@@ -12,6 +12,51 @@ const toMongoAndTextSearch = value =>
         .map(term => `"${term.replace(/(["\\])/g, '\\$1')}"`)
         .join(' ');
 
+// MongoDB rejects $text inside $not and $nor, so an $and or an $or branch list are the
+// only places a nested $text clause can show up.
+const TEXT_QUERY_BRANCHES = ['$and', '$or'];
+
+// MongoDB resolves a $text expression through the compound `fulltext` index, which is
+// prefixed with `user`, so the branch holding $text must also match on `user`. On top of
+// that MongoDB only plans an $or holding a $text clause when every branch of that $or is
+// index backed. Stamping the user id on each branch of every $or that wraps the $text
+// clause satisfies both rules. The filter always requires `user` at the top level, so the
+// repeated equality never changes what the filter matches.
+// Returns true when the subtree holds a $text clause.
+const applyTextIndexPrefix = (filter, user) => {
+    if (!filter || typeof filter !== 'object') {
+        return false;
+    }
+
+    if (Array.isArray(filter)) {
+        let branchWithTextQuery = false;
+        for (let branch of filter) {
+            if (applyTextIndexPrefix(branch, user)) {
+                branchWithTextQuery = true;
+            }
+        }
+        return branchWithTextQuery;
+    }
+
+    let hasTextQuery = filter.$text !== undefined;
+
+    for (let key of TEXT_QUERY_BRANCHES) {
+        if (filter[key] === undefined || !applyTextIndexPrefix(filter[key], user)) {
+            continue;
+        }
+
+        hasTextQuery = true;
+
+        if (key === '$or') {
+            for (let branch of filter.$or) {
+                branch.user = user;
+            }
+        }
+    }
+
+    return hasTextQuery;
+};
+
 const SEARCHABLE_MAILBOX_SPECIAL_USE = ['\\Junk', '\\Trash'];
 const SEARCHABLE_MAILBOX_IN_THRESHOLD = 200;
 
@@ -356,7 +401,9 @@ const prepareSearchFilter = async (db, user, payload) => {
         filter.$or = orQuery;
     }
 
+    applyTextIndexPrefix(filter, user);
+
     return { filter, query };
 };
 
-module.exports = { uidRangeStringToQuery, prepareSearchFilter, toMongoAndTextSearch, getSearchableMailboxQuery };
+module.exports = { uidRangeStringToQuery, prepareSearchFilter, toMongoAndTextSearch, getSearchableMailboxQuery, applyTextIndexPrefix };

--- a/lib/search-query.js
+++ b/lib/search-query.js
@@ -43,7 +43,11 @@ const getDateValue = value => {
     return isNaN(date.getTime()) ? false : date;
 };
 
-const createMongoTextQuery = searchValue => ({
+const createMongoTextQuery = (user, searchValue) => ({
+    // Keep the compound text index prefix in the same logical branch as $text.
+    // MongoDB does not propagate the top-level predicate into a nested $or
+    // branch when selecting the text index.
+    user,
     $text: {
         $search: searchValue
     }
@@ -286,7 +290,7 @@ const getMongoDBQuery = async (db, user, queryStr, opts = {}) => {
         const searchValue = getTextSearchValue(entry);
         return {
             ...entry,
-            query: createMongoTextQuery(searchValue)
+            query: createMongoTextQuery(user, searchValue)
         };
     };
     const isTextEntry = entry => !!entry?.isTextQuery;
@@ -301,7 +305,7 @@ const getMongoDBQuery = async (db, user, queryStr, opts = {}) => {
             negated: false,
             rawSearch: true,
             entries,
-            query: createMongoTextQuery(searchValue)
+            query: createMongoTextQuery(user, searchValue)
         };
     };
 

--- a/lib/search-query.js
+++ b/lib/search-query.js
@@ -3,7 +3,7 @@
 const SearchString = require('search-string').default;
 const parser = require('logic-query-parser');
 const { escapeRegexStr } = require('./tools');
-const { uidRangeStringToQuery, toMongoAndTextSearch, getSearchableMailboxQuery } = require('./prepare-search-filter');
+const { uidRangeStringToQuery, toMongoAndTextSearch, getSearchableMailboxQuery, applyTextIndexPrefix } = require('./prepare-search-filter');
 const { ObjectId } = require('mongodb');
 
 const getBooleanValue = value => {
@@ -43,17 +43,15 @@ const getDateValue = value => {
     return isNaN(date.getTime()) ? false : date;
 };
 
-const createMongoTextQuery = (user, searchValue) => ({
-    // Keep the compound text index prefix in the same logical branch as $text.
-    // MongoDB does not propagate the top-level predicate into a nested $or
-    // branch when selecting the text index.
-    user,
+const createMongoTextQuery = searchValue => ({
     $text: {
         $search: searchValue
     }
 });
 
-const formatTextSearchValue = (value, opts = {}) => (opts.useAndSearch === true && opts.mode !== 'or' ? toMongoAndTextSearch(value) : value);
+const isAndSearch = (opts = {}) => opts.useAndSearch === true && opts.mode !== 'or';
+
+const formatTextSearchValue = (value, opts = {}) => (isAndSearch(opts) ? toMongoAndTextSearch(value) : value);
 
 const createPhraseRegexClauses = value => {
     const regex = escapeRegexStr(value).replace(/\s+/g, '\\s+');
@@ -290,13 +288,36 @@ const getMongoDBQuery = async (db, user, queryStr, opts = {}) => {
         const searchValue = getTextSearchValue(entry);
         return {
             ...entry,
-            query: createMongoTextQuery(user, searchValue)
+            query: createMongoTextQuery(searchValue)
         };
     };
     const isTextEntry = entry => !!entry?.isTextQuery;
-    const unwrapQueryEntry = entry => (isTextEntry(entry) ? entry.query : entry);
     const createTextRegexQuery = entry => createPhraseQuery(entry.textValue, entry.negated);
-    const createRawTextRegexQuery = entry => ({ $or: entry.entries.map(createTextRegexQuery) });
+    const createRawTextRegexQuery = entry => {
+        const included = entry.entries.filter(item => !item.negated).map(createTextRegexQuery);
+        const excluded = entry.entries.filter(item => item.negated).map(createTextRegexQuery);
+        // $text applies negated terms as exclusions, so those stay ANDed even when the
+        // remaining terms are ORed
+        const clauses = (entry.andSearch || included.length < 2 ? included : [{ $or: included }]).concat(excluded);
+
+        return clauses.length === 1 ? clauses[0] : { $and: clauses };
+    };
+    // MongoDB allows a single $text expression per query. The first text term the walk
+    // reaches claims it, the ones that can not be merged into it, eg. because they sit in
+    // a different OR branch, fall back to the same regex matching quoted phrases use.
+    let textQueryUsed = false;
+    const unwrapQueryEntry = entry => {
+        if (!isTextEntry(entry)) {
+            return entry;
+        }
+
+        if (textQueryUsed) {
+            return entry.rawSearch ? createRawTextRegexQuery(entry) : createTextRegexQuery(entry);
+        }
+
+        textQueryUsed = true;
+        return entry.query;
+    };
     const mergeTextEntries = (entries, queryOpts = opts) => {
         const searchValue = entries.map(entry => getTextSearchValue(entry, queryOpts)).join(' ');
         return {
@@ -304,8 +325,10 @@ const getMongoDBQuery = async (db, user, queryStr, opts = {}) => {
             textValue: searchValue,
             negated: false,
             rawSearch: true,
+            // remember how the merged terms are combined, the regex fallback has to match it
+            andSearch: isAndSearch(queryOpts),
             entries,
-            query: createMongoTextQuery(user, searchValue)
+            query: createMongoTextQuery(searchValue)
         };
     };
 
@@ -352,10 +375,7 @@ const getMongoDBQuery = async (db, user, queryStr, opts = {}) => {
                     let directTextTerms = textTerms.filter(entry => !entry.rawSearch);
 
                     if (rawTextTerms.length) {
-                        branch.$and = [unwrapQueryEntry(rawTextTerms.shift())]
-                            .concat(rawTextTerms.map(createRawTextRegexQuery))
-                            .concat(directTextTerms.map(createTextRegexQuery))
-                            .concat(nonTextTerms);
+                        branch.$and = rawTextTerms.concat(directTextTerms).map(unwrapQueryEntry).concat(nonTextTerms);
                     } else {
                         branch.$and = [unwrapQueryEntry(mergeTextEntries(textTerms))].concat(nonTextTerms);
                     }
@@ -744,6 +764,8 @@ const getMongoDBQuery = async (db, user, queryStr, opts = {}) => {
         if (hasTextFilter) {
             extras.searchable = true;
         }
+
+        applyTextIndexPrefix(filter, user);
 
         return { user: null, ...filter, ...extras };
     }

--- a/test/api/messages-test.js
+++ b/test/api/messages-test.js
@@ -179,6 +179,7 @@ describe('Search query parser tests', function () {
             user,
             $and: [
                 {
+                    user,
                     $text: {
                         $search: 'foo'
                     }
@@ -229,6 +230,7 @@ describe('Search query parser tests', function () {
             user,
             $and: [
                 {
+                    user,
                     $text: {
                         $search: 'phrase'
                     }
@@ -240,6 +242,27 @@ describe('Search query parser tests', function () {
                 }
             ],
             searchable: true
+        });
+    });
+
+    it('should include text index prefix in mixed OR text branches', async () => {
+        const db = {
+            database: {
+                collection() {
+                    throw new Error('Unexpected database lookup');
+                }
+            }
+        };
+        const user = new ObjectId();
+        const query = await getMongoDBQuery(db, user, 'from:1.1.2021 OR to:31.12.2024 example', { useAndSearch: true });
+
+        expect(query.user).to.equal(user);
+        expect(query.searchable).to.be.true;
+        expect(query.$and[0].$or[1].$and[1]).to.deep.equal({
+            user,
+            $text: {
+                $search: '"example"'
+            }
         });
     });
 });
@@ -1496,6 +1519,18 @@ describe('Messages tests', function () {
 
         expect(getSubjects(search)).to.include(queryFixture.subjectKeyword);
         expect(getSubjects(search)).to.include(queryFixture.subjectAttachment);
+    });
+
+    it('should GET /users/:user/search expect success / q supports mixed header and fulltext OR branches', async () => {
+        const q = 'from:1.1.2021 OR to:31.12.2024 example';
+        const search = await server
+            .get(`/users/${user}/search?q=${encodeURIComponent(q)}&searchable=1&threadCounters=1&limit=100&order=desc&useAndSearch=1`)
+            .send({})
+            .expect(200);
+
+        expect(search.body.success).to.be.true;
+        expect(search.body.query).to.equal(q);
+        expect(search.body.results).to.be.an('array');
     });
 
     it('should GET /users/:user/search expect success / q supports OR between quoted from and to keywords', async () => {

--- a/test/api/messages-test.js
+++ b/test/api/messages-test.js
@@ -12,10 +12,20 @@ const config = require('@zone-eu/wild-config');
 const { ObjectId } = require('mongodb');
 const { ImapFlow } = require('imapflow');
 const { parseSearchQuery, getMongoDBQuery } = require('../../lib/search-query');
+const { prepareSearchFilter } = require('../../lib/prepare-search-filter');
 
 const server = supertest.agent(`http://127.0.0.1:${config.api.port}`);
 
 describe('Search query parser tests', function () {
+    const noDbLookup = {
+        database: {
+            collection() {
+                throw new Error('Unexpected database lookup');
+            }
+        }
+    };
+    const headerMatch = (key, regex) => ({ headers: { $elemMatch: { key, value: { $regex: regex, $options: 'i' } } } });
+
     it('should parse quoted multi-word text as an exact phrase only when quoted', () => {
         const unquoted = parseSearchQuery('phrase here');
         const quoted = parseSearchQuery('"phrase here"');
@@ -179,7 +189,6 @@ describe('Search query parser tests', function () {
             user,
             $and: [
                 {
-                    user,
                     $text: {
                         $search: 'foo'
                     }
@@ -230,7 +239,6 @@ describe('Search query parser tests', function () {
             user,
             $and: [
                 {
-                    user,
                     $text: {
                         $search: 'phrase'
                     }
@@ -245,24 +253,135 @@ describe('Search query parser tests', function () {
         });
     });
 
-    it('should include text index prefix in mixed OR text branches', async () => {
+    it('should tag every OR branch wrapping a $text clause with the user id', async () => {
+        const user = new ObjectId();
+
+        // MongoDB only plans an $or holding a $text clause when every branch of that $or
+        // is index backed, and the text index is prefixed with `user`
+        expect(await getMongoDBQuery(noDbLookup, user, 'from:1.1.2021 OR to:31.12.2024 example', { useAndSearch: true })).to.deep.equal({
+            user,
+            $and: [
+                {
+                    $or: [
+                        {
+                            user,
+                            ...headerMatch('from', '1\\.1\\.2021')
+                        },
+                        {
+                            user,
+                            $and: [
+                                {
+                                    $or: [headerMatch('to', '31\\.12\\.2024'), headerMatch('cc', '31\\.12\\.2024'), headerMatch('bcc', '31\\.12\\.2024')]
+                                },
+                                {
+                                    $text: {
+                                        $search: '"example"'
+                                    }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            searchable: true
+        });
+    });
+
+    it('should tag OR branches on every level between the root and a $text clause', async () => {
+        const user = new ObjectId();
+        const query = await getMongoDBQuery(noDbLookup, user, 'from:sender (example OR to:rcpt) OR subject:topic', { useAndSearch: true });
+
+        const outer = query.$and[0].$or;
+        expect(outer.every(branch => branch.user === user)).to.be.true;
+
+        const inner = outer.find(branch => branch.$and).$and.find(branch => branch.$or).$or;
+        expect(inner.every(branch => branch.user === user)).to.be.true;
+        expect(inner.some(branch => branch.$text)).to.be.true;
+    });
+
+    it('should not tag OR branches when the query has no $text clause', async () => {
+        const user = new ObjectId();
+        const query = await getMongoDBQuery(noDbLookup, user, 'from:sender OR subject:topic');
+
+        expect(query.$and[0].$or.every(branch => !('user' in branch))).to.be.true;
+    });
+
+    it('should emit a single $text clause and fall back to regex for the rest', async () => {
+        const user = new ObjectId();
+        const countTextClauses = value => {
+            if (!value || typeof value !== 'object') {
+                return 0;
+            }
+            if (Array.isArray(value)) {
+                return value.reduce((sum, entry) => sum + countTextClauses(entry), 0);
+            }
+            return Object.entries(value).reduce((sum, [key, entry]) => sum + (key === '$text' ? 1 : countTextClauses(entry)), 0);
+        };
+
+        // MongoDB rejects a query holding more than one $text expression
+        for (let q of ['from:sender first OR to:rcpt second', 'first OR from:sender OR second', 'first second OR third fourth']) {
+            expect(countTextClauses(await getMongoDBQuery(noDbLookup, user, q, { useAndSearch: true }))).to.equal(1);
+        }
+    });
+
+    it('should keep AND semantics when a merged text clause falls back to regex', async () => {
+        const user = new ObjectId();
+        const query = await getMongoDBQuery(noDbLookup, user, 'first second OR third fourth', { useAndSearch: true });
+        const fallback = query.$and[0].$or[1].$and[0];
+
+        // `third fourth` was an AND of two terms before losing the $text slot
+        expect(fallback.$and).to.have.lengthOf(2);
+        expect(fallback.$or).to.be.undefined;
+    });
+
+    it('should keep negated terms excluding when a merged text clause falls back to regex', async () => {
+        const user = new ObjectId();
+        const losingBranch = async q => (await getMongoDBQuery(noDbLookup, user, q)).$and[0].$or[1].$and[0];
+
+        // $text applies a negated term as an exclusion even in OR mode, so `gamma -delta`
+        // means gamma AND NOT delta, not gamma OR NOT delta
+        const negated = await losingBranch('alpha beta OR gamma -delta');
+        expect(negated.$and).to.have.lengthOf(2);
+        expect(negated.$and[1].$nor).to.not.be.undefined;
+
+        // without a negated term the merged OR terms stay ORed
+        const plain = await losingBranch('alpha beta OR gamma delta');
+        expect(plain.$or).to.have.lengthOf(2);
+        expect(plain.$and).to.be.undefined;
+    });
+
+    it('should tag the $text branch of an or.* search filter with the user id', async () => {
+        const user = new ObjectId();
         const db = {
-            database: {
+            ...noDbLookup,
+            users: {
                 collection() {
-                    throw new Error('Unexpected database lookup');
+                    return {
+                        findOne() {
+                            return Promise.resolve({ _id: user, username: 'searchuser', address: 'searchuser@example.com' });
+                        }
+                    };
                 }
             }
         };
-        const user = new ObjectId();
-        const query = await getMongoDBQuery(db, user, 'from:1.1.2021 OR to:31.12.2024 example', { useAndSearch: true });
 
-        expect(query.user).to.equal(user);
-        expect(query.searchable).to.be.true;
-        expect(query.$and[0].$or[1].$and[1]).to.deep.equal({
+        const { filter } = await prepareSearchFilter(db, user, { or: { query: 'example', from: 'sender' }, useAndSearch: true });
+
+        expect(filter).to.deep.equal({
             user,
-            $text: {
-                $search: '"example"'
-            }
+            searchable: true,
+            $or: [
+                {
+                    user,
+                    $text: {
+                        $search: '"example"'
+                    }
+                },
+                {
+                    user,
+                    ...headerMatch('from', 'sender')
+                }
+            ]
         });
     });
 });
@@ -325,9 +444,9 @@ describe('Messages tests', function () {
         altFromAddress: 'search.query.alt-from@web.zone.test'
     };
 
-    const searchQ = async q => {
+    const searchQ = async (q, params = {}) => {
         const search = await server
-            .get(`/users/${user}/search?q=${encodeURIComponent(q)}&limit=50`)
+            .get(`/users/${user}/search?${new URLSearchParams({ q, limit: 50, ...params })}`)
             .send({})
             .expect(200);
 
@@ -337,6 +456,7 @@ describe('Messages tests', function () {
         return search.body;
     };
 
+    const postQueryMessage = message => server.post(`/users/${user}/mailboxes/${queryMailbox}/messages`).send(message).expect(200);
     const getSubjects = body => body.results.map(entry => entry.subject);
     const getIds = body => body.results.map(entry => entry.id);
     const ensureMoreThanSearchableMailboxThreshold = async () => {
@@ -1522,15 +1642,98 @@ describe('Messages tests', function () {
     });
 
     it('should GET /users/:user/search expect success / q supports mixed header and fulltext OR branches', async () => {
-        const q = 'from:1.1.2021 OR to:31.12.2024 example';
-        const search = await server
-            .get(`/users/${user}/search?q=${encodeURIComponent(q)}&searchable=1&threadCounters=1&limit=100&order=desc&useAndSearch=1`)
-            .send({})
-            .expect(200);
+        const suffix = Date.now().toString(36);
+        const senderAddress = `search.query.mixed-from-${suffix}@web.zone.test`;
+        const recipientAddress = `search.query.mixed-to-${suffix}@to.com`;
+        const bodyToken = `searchquerymixedbody${suffix}`;
+        const fromSubject = 'Search Query Mixed OR From Marker';
+        const toSubject = 'Search Query Mixed OR To Marker';
+        const decoySubject = 'Search Query Mixed OR Decoy Marker';
 
-        expect(search.body.success).to.be.true;
-        expect(search.body.query).to.equal(q);
-        expect(search.body.results).to.be.an('array');
+        // matches the header branch only
+        await postQueryMessage({
+            date: new Date('2021-01-10T10:00:00.000Z'),
+            from: { address: senderAddress },
+            to: [{ address: queryFixture.otherAddress }],
+            subject: fromSubject,
+            text: 'mixed or from side'
+        });
+
+        // matches the recipient and fulltext branch
+        await postQueryMessage({
+            date: new Date('2021-01-10T11:00:00.000Z'),
+            from: { address: queryFixture.otherAddress },
+            to: [{ address: recipientAddress }],
+            subject: toSubject,
+            text: `mixed or to side ${bodyToken}`
+        });
+
+        // matches the recipient but not the fulltext term, so the AND branch must reject it
+        await postQueryMessage({
+            date: new Date('2021-01-10T12:00:00.000Z'),
+            from: { address: queryFixture.otherAddress },
+            to: [{ address: recipientAddress }],
+            subject: decoySubject,
+            text: 'mixed or decoy side'
+        });
+
+        const q = `from:${senderAddress} OR to:${recipientAddress} ${bodyToken}`;
+
+        // the same query has to plan both with and without the searchable mailbox filter
+        for (let params of [{ useAndSearch: 1 }, { useAndSearch: 1, searchable: 1 }]) {
+            const search = await searchQ(q, params);
+            const subjects = getSubjects(search);
+
+            expect(subjects).to.include(fromSubject);
+            expect(subjects).to.include(toSubject);
+            expect(subjects).to.not.include(decoySubject);
+            expect(subjects).to.not.include(queryFixture.subjectKeyword);
+        }
+    });
+
+    it('should GET /users/:user/search expect success / q supports fulltext terms in more than one OR branch', async () => {
+        const suffix = Date.now().toString(36);
+        const senderAddress = `search.query.multi-from-${suffix}@web.zone.test`;
+        const recipientAddress = `search.query.multi-to-${suffix}@to.com`;
+        const firstToken = `searchquerymultifirst${suffix}`;
+        const secondToken = `searchquerymultisecond${suffix}`;
+        const firstSubject = 'Search Query Multi Text OR First Marker';
+        const secondSubject = 'Search Query Multi Text OR Second Marker';
+        const decoySubject = 'Search Query Multi Text OR Decoy Marker';
+
+        await postQueryMessage({
+            date: new Date('2021-01-11T10:00:00.000Z'),
+            from: { address: senderAddress },
+            to: [{ address: queryFixture.otherAddress }],
+            subject: firstSubject,
+            text: `multi text first side ${firstToken}`
+        });
+
+        await postQueryMessage({
+            date: new Date('2021-01-11T11:00:00.000Z'),
+            from: { address: queryFixture.otherAddress },
+            to: [{ address: recipientAddress }],
+            subject: secondSubject,
+            text: `multi text second side ${secondToken}`
+        });
+
+        // right sender, wrong fulltext term
+        await postQueryMessage({
+            date: new Date('2021-01-11T12:00:00.000Z'),
+            from: { address: senderAddress },
+            to: [{ address: queryFixture.otherAddress }],
+            subject: decoySubject,
+            text: `multi text decoy side ${secondToken}`
+        });
+
+        // MongoDB only accepts a single $text expression, the second term falls back to regex
+        const q = `from:${senderAddress} ${firstToken} OR to:${recipientAddress} ${secondToken}`;
+        const search = await searchQ(q, { useAndSearch: 1, searchable: 1 });
+        const subjects = getSubjects(search);
+
+        expect(subjects).to.include(firstSubject);
+        expect(subjects).to.include(secondSubject);
+        expect(subjects).to.not.include(decoySubject);
     });
 
     it('should GET /users/:user/search expect success / q supports OR between quoted from and to keywords', async () => {


### PR DESCRIPTION
## Problem

`GET /users/:user/search` returned HTTP 500 for any query that puts a fulltext term inside an OR branch, for example the reported

```
?q=from%3A1.1.2021+OR+to%3A31.12.2024+enico&searchable=1&useAndSearch=1
```

```
planner returned error :: caused by :: failed to use text index to satisfy $text query
(if text index is compound, are equality predicates given for all prefix fields?)
```

MongoDB puts two conditions on a `$text` expression nested inside an `$or`:

1. the `fulltext` index is compound (`{user: 1, 'headers.value': text, text: text}`), so the branch holding `$text` needs its own equality match on `user`. A top level `user` is not propagated into the branch.
2. every other branch of that same `$or` has to be index backed, otherwise the planner gives up with `No query solutions`.

On top of that MongoDB accepts only one `$text` expression per query, and the builder emitted two whenever text terms landed in different OR branches (`Too many text expressions`).

## Fix

`applyTextIndexPrefix(filter, user)` walks the finished filter and stamps `user` onto every branch of every `$or` that wraps a `$text` clause. The filter always requires `user` at the top level, so the repeated equality never changes what the filter matches, but it gives the text branch its index prefix and gives the sibling branches an index to scan. Both filter builders call it, so the `or.*` API params (`lib/prepare-search-filter.js`) are covered as well, not only `q=` (`lib/search-query.js`).

A `textQueryUsed` guard keeps a single `$text` per query. Terms that cannot claim it fall back to the regex matching the builder already uses for quoted phrases. That fallback now mirrors `$text` semantics: a merged AND term stays ANDed, and a negated term keeps excluding instead of widening the result set.

## Verified

Against MongoDB 7 with the full `messages` index set from `indexes.yaml`:

- 42 query shapes that previously produced `failed to use text index`, `No query solutions` or `Too many text expressions` now all plan, every one of them as `TEXT_MATCH` over the `fulltext` index, no collection scans
- 24 seeded corpus queries return exactly the documents the query logically selects, including the regex fallback branches

Test suites: `test/api/messages-test.js` 100 passing, full API suite 681 passing, protocol and unit suites 385 passing.

## Note, out of scope

`lib/handlers/on-search.js:71` is the third `$text` producer in the repo. It hoists an IMAP `TEXT`/`BODY` term to the root of the query on the strength of a comment saying fulltext cannot live inside `$or`. That path was checked against MongoDB and is safe as written, but the comment is now only half true and the hoisting changes what an `OR TEXT ...` search matches. Worth a separate look.
