### PR TITLE
fix(proxy): guard the raw socket while parsing the PROXY header

### DIFF
--- a/imap-core/lib/imap-server.js
+++ b/imap-core/lib/imap-server.js
@@ -58,7 +58,11 @@ class IMAPServer extends EventEmitter {
                 socket.setKeepAlive(true, 5 * 1000);
                 this._handleProxy(socket, (err, socketOptions) => {
                     if (err) {
-                        // ignore, should not happen
+                        // PROXY header could not be read (client dropped the
+                        // connection or sent garbage). The socket is already
+                        // closing/closed and guarded against late errors in
+                        // _handleProxy; just don't proceed to connect().
+                        return;
                     }
                     if (this.options.secured) {
                         return this.connect(socket, socketOptions);
@@ -75,7 +79,9 @@ class IMAPServer extends EventEmitter {
             this.server = net.createServer(this.options, socket =>
                 this._handleProxy(socket, (err, socketOptions) => {
                     if (err) {
-                        // ignore, should not happen
+                        // socket already closing/closed and guarded in
+                        // _handleProxy; just don't proceed to connect()
+                        return;
                     }
                     socket.setKeepAlive(true, 5 * 1000);
                     this.connect(socket, socketOptions);
@@ -251,13 +257,85 @@ class IMAPServer extends EventEmitter {
 
         let chunks = [];
         let chunklen = 0;
-        let socketReader = () => {
+        let finished = false;
+
+        let onError;
+        let onClose;
+        let onEnd;
+        let socketReader;
+
+        let cleanup = () => {
+            socket.removeListener('readable', socketReader);
+            socket.removeListener('error', onError);
+            socket.removeListener('close', onClose);
+            socket.removeListener('end', onEnd);
+        };
+
+        let done = (err, opts) => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            if (err) {
+                // The socket is already closing/closed (RST/FIN seen, or we
+                // issued socket.end() with a diagnostic). Attach a no-op 'error'
+                // handler BEFORE removing ours, so the socket is never left
+                // without one — a late in-flight error (e.g. EPIPE while
+                // flushing "* BAD") must not surface as an uncaughtException.
+                socket.on('error', () => {
+                    // ignore
+                });
+            }
+            cleanup();
+            callback(err, opts);
+        };
+
+        onError = err => {
+            // client may close the connection (RST/FIN) before sending the
+            // PROXY header; surface the error through the callback instead of
+            // letting it bubble up as an uncaught exception
+            this.logger.info(
+                {
+                    tnx: 'proxy',
+                    cid: socketOptions.id,
+                    err
+                },
+                '[%s] PROXY socket error before header was received: %s',
+                socketOptions.id,
+                err.message
+            );
+            done(err);
+        };
+
+        onClose = () => {
+            // socket closed before a full PROXY header arrived
+            done(new Error('Socket closed before PROXY header was received'));
+        };
+
+        onEnd = () => {
+            // client half-closed (FIN) before a full PROXY header arrived; with
+            // allowHalfOpen the socket emits 'end' but never 'close', so without
+            // this the connection would linger until socketTimeout
+            done(new Error('Socket ended before PROXY header was received'));
+        };
+
+        // reject a malformed/non-PROXY header: deliver the diagnostic to the
+        // client (best effort) and surface the failure through the single done()
+        let rejectInvalid = message => {
+            try {
+                socket.end('* BAD Invalid PROXY header\r\n');
+            } catch (E) {
+                // ignore
+            }
+            return done(new Error(message || 'Invalid PROXY header'));
+        };
+
+        socketReader = () => {
             let chunk;
             while ((chunk = socket.read()) !== null) {
                 for (let i = 0, len = chunk.length; i < len; i++) {
                     let chr = chunk[i];
                     if (chr === 0x0a) {
-                        socket.removeListener('readable', socketReader);
                         chunks.push(chunk.slice(0, i + 1));
                         chunklen += i + 1;
                         let remainder = chunk.slice(i + 1);
@@ -270,12 +348,7 @@ class IMAPServer extends EventEmitter {
                         let params = (header || '').toString().split(' ');
                         let commandName = params.shift().toUpperCase();
                         if (commandName !== 'PROXY') {
-                            try {
-                                socket.end('* BAD Invalid PROXY header\r\n');
-                            } catch (E) {
-                                // ignore
-                            }
-                            return;
+                            return rejectInvalid();
                         }
 
                         if (params[1]) {
@@ -303,14 +376,18 @@ class IMAPServer extends EventEmitter {
                             }
                         }
 
-                        return callback(null, socketOptions);
+                        return done(null, socketOptions);
                     }
                 }
                 chunks.push(chunk);
                 chunklen += chunk.length;
             }
         };
+
         socket.on('readable', socketReader);
+        socket.on('error', onError);
+        socket.on('close', onClose);
+        socket.on('end', onEnd);
     }
 
     _upgrade(socket, callback) {

--- a/imap-core/test/proxy-socket-error-test.js
+++ b/imap-core/test/proxy-socket-error-test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+/* eslint-disable no-unused-expressions */
+
+// Regression tests for the PROXY-protocol parsing window in IMAPServer.
+//
+// _handleProxy runs on the raw accepted socket before the connection object
+// (and its error handler) exists. If the client resets or half-closes while
+// the server is waiting for the PROXY header, the socket used to emit 'error'
+// with no listener, which crashes the whole process with an unhandled
+// ECONNRESET. These tests drive those paths and assert the server survives.
+
+const chai = require('chai');
+const expect = chai.expect;
+const IMAPServer = require('../index.js').IMAPServer;
+const net = require('net');
+
+chai.config.includeStack = true;
+
+const TEST_PORT = 0; // let the OS assign an available port
+
+describe('IMAP PROXY socket error handling', () => {
+    let server;
+
+    afterEach(done => {
+        if (server) {
+            return server.close(() => {
+                server = false;
+                done();
+            });
+        }
+        return done();
+    });
+
+    it('should survive a client reset while waiting for the PROXY header', done => {
+        let finished = false;
+
+        const onUncaught = err => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            process.removeListener('uncaughtException', onUncaught);
+            done(new Error('unhandled socket error during PROXY window: ' + (err && err.message)));
+        };
+        // run before mocha's own handler so the failure names the real cause
+        process.prependOnceListener('uncaughtException', onUncaught);
+
+        server = new IMAPServer({ useProxy: ['*'], logger: false });
+        server.on('error', () => {}); // must not throw at the server level either
+
+        server.listen(TEST_PORT, '127.0.0.1', () => {
+            const port = server.server.address().port;
+            const client = net.connect(port, '127.0.0.1', () => {
+                client.on('error', () => {}); // client-side RST noise, irrelevant
+                client.resetAndDestroy(); // send RST before any PROXY header
+            });
+
+            // if no uncaughtException fires within the grace window, the fix held
+            setTimeout(() => {
+                if (finished) {
+                    return;
+                }
+                finished = true;
+                process.removeListener('uncaughtException', onUncaught);
+                done();
+            }, 200);
+        });
+    });
+
+    it('should survive a malformed PROXY header followed by a reset', done => {
+        let finished = false;
+
+        const onUncaught = err => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            process.removeListener('uncaughtException', onUncaught);
+            done(new Error('unhandled socket error after invalid PROXY header: ' + (err && err.message)));
+        };
+        process.prependOnceListener('uncaughtException', onUncaught);
+
+        server = new IMAPServer({ useProxy: ['*'], logger: false });
+        server.on('error', () => {});
+
+        server.listen(TEST_PORT, '127.0.0.1', () => {
+            const port = server.server.address().port;
+            const client = net.connect(port, '127.0.0.1', () => {
+                client.on('error', () => {});
+                // a non-PROXY line makes the server flush "* BAD" and reject; the
+                // reset that follows must not surface as a late unhandled error
+                client.write('GARBAGE not-a-proxy-line\r\n');
+                setImmediate(() => client.resetAndDestroy());
+            });
+
+            setTimeout(() => {
+                if (finished) {
+                    return;
+                }
+                finished = true;
+                process.removeListener('uncaughtException', onUncaught);
+                done();
+            }, 200);
+        });
+    });
+
+    it('should still parse a valid PROXY header and expose the proxied address', done => {
+        let finished = false;
+
+        server = new IMAPServer({ useProxy: ['*'], logger: false });
+        server.on('error', () => {});
+        server.onAuth = (login, session, callback) => callback(null, { user: { id: '1' } });
+
+        server.listen(TEST_PORT, '127.0.0.1', () => {
+            const port = server.server.address().port;
+            const client = net.connect(port, '127.0.0.1', () => {
+                client.write('PROXY TCP4 203.0.113.7 10.0.0.1 51234 143\r\n');
+            });
+
+            let buf = '';
+            client.on('data', data => {
+                buf += data.toString();
+                if (finished || !/\* OK/.test(buf)) {
+                    return;
+                }
+                finished = true;
+                expect(buf).to.include('* OK');
+                // the greeting reports the address carried by the PROXY header,
+                // proving the header was parsed rather than the socket peer used
+                expect(buf).to.include('203.0.113.7');
+                client.end();
+                return done();
+            });
+
+            client.on('error', err => {
+                if (!finished) {
+                    finished = true;
+                    return done(err);
+                }
+            });
+        });
+    });
+});

--- a/lib/pop3/server.js
+++ b/lib/pop3/server.js
@@ -49,7 +49,11 @@ class POP3Server extends EventEmitter {
             this.server = net.createServer(this.options, socket => {
                 this._handleProxy(socket, (err, socketOptions) => {
                     if (err) {
-                        // ignore, should not happen
+                        // PROXY header could not be read (client dropped the
+                        // connection or sent garbage). The socket is already
+                        // closing/closed and guarded against late errors in
+                        // _handleProxy; just don't proceed to connect().
+                        return;
                     }
                     if (this.options.secured) {
                         return this.connect(socket, socketOptions);
@@ -66,7 +70,9 @@ class POP3Server extends EventEmitter {
             this.server = net.createServer(this.options, socket => {
                 this._handleProxy(socket, (err, socketOptions) => {
                     if (err) {
-                        // ignore, should not happen
+                        // socket already closing/closed and guarded in
+                        // _handleProxy; just don't proceed to connect()
+                        return;
                     }
                     this.connect(socket, socketOptions);
                 });
@@ -300,19 +306,87 @@ class POP3Server extends EventEmitter {
             return setImmediate(() => callback(null, socketOptions));
         }
 
-        if (!this.options.useProxy) {
-            return setImmediate(callback);
-        }
-
         let chunks = [];
         let chunklen = 0;
-        let socketReader = () => {
+        let finished = false;
+
+        let onError;
+        let onClose;
+        let onEnd;
+        let socketReader;
+
+        let cleanup = () => {
+            socket.removeListener('readable', socketReader);
+            socket.removeListener('error', onError);
+            socket.removeListener('close', onClose);
+            socket.removeListener('end', onEnd);
+        };
+
+        let done = (err, opts) => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            if (err) {
+                // The socket is already closing/closed (RST/FIN seen, or we
+                // issued socket.end() with a diagnostic). Attach a no-op 'error'
+                // handler BEFORE removing ours, so the socket is never left
+                // without one — a late in-flight error (e.g. EPIPE while
+                // flushing "-ERR") must not surface as an uncaughtException.
+                socket.on('error', () => {
+                    // ignore
+                });
+            }
+            cleanup();
+            callback(err, opts);
+        };
+
+        onError = err => {
+            // client may close the connection (RST/FIN) before sending the
+            // PROXY header; surface the error through the callback instead of
+            // letting it bubble up as an uncaught exception
+            this.logger.info(
+                {
+                    tnx: 'proxy',
+                    cid: socketOptions.id,
+                    err
+                },
+                '[%s] PROXY socket error before header was received: %s',
+                socketOptions.id,
+                err.message
+            );
+            done(err);
+        };
+
+        onClose = () => {
+            // socket closed before a full PROXY header arrived
+            done(new Error('Socket closed before PROXY header was received'));
+        };
+
+        onEnd = () => {
+            // client half-closed (FIN) before a full PROXY header arrived; with
+            // allowHalfOpen the socket emits 'end' but never 'close', so without
+            // this the connection would linger until socketTimeout
+            done(new Error('Socket ended before PROXY header was received'));
+        };
+
+        // reject a malformed/non-PROXY header: deliver the diagnostic to the
+        // client (best effort) and surface the failure through the single done()
+        let rejectInvalid = message => {
+            try {
+                socket.end('-ERR Invalid PROXY header\r\n');
+            } catch (E) {
+                // ignore
+            }
+            return done(new Error(message || 'Invalid PROXY header'));
+        };
+
+        socketReader = () => {
             let chunk;
             while ((chunk = socket.read()) !== null) {
                 for (let i = 0, len = chunk.length; i < len; i++) {
                     let chr = chunk[i];
                     if (chr === 0x0a) {
-                        socket.removeListener('readable', socketReader);
                         chunks.push(chunk.slice(0, i + 1));
                         chunklen += i + 1;
                         let remainder = chunk.slice(i + 1);
@@ -325,12 +399,7 @@ class POP3Server extends EventEmitter {
                         let params = (header || '').toString().split(' ');
                         let commandName = params.shift().toUpperCase();
                         if (commandName !== 'PROXY') {
-                            try {
-                                socket.end('-ERR Invalid PROXY header\r\n');
-                            } catch (E) {
-                                // ignore
-                            }
-                            return;
+                            return rejectInvalid();
                         }
 
                         if (params[1]) {
@@ -357,14 +426,18 @@ class POP3Server extends EventEmitter {
                             }
                         }
 
-                        return callback(null, socketOptions);
+                        return done(null, socketOptions);
                     }
                 }
                 chunks.push(chunk);
                 chunklen += chunk.length;
             }
         };
+
         socket.on('readable', socketReader);
+        socket.on('error', onError);
+        socket.on('close', onClose);
+        socket.on('end', onEnd);
     }
 
     connect(socket, socketOptions) {

--- a/test/pop3-proxy-socket-error-test.js
+++ b/test/pop3-proxy-socket-error-test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/* eslint-disable no-unused-expressions */
+
+// Regression tests for the PROXY-protocol parsing window in POP3Server.
+// Mirrors imap-core/test/proxy-socket-error-test.js: a client that resets
+// while the server waits for the PROXY header used to crash the process with
+// an unhandled ECONNRESET, because the raw socket had no error handler yet.
+
+const chai = require('chai');
+const expect = chai.expect;
+const POP3Server = require('../lib/pop3/server');
+const net = require('net');
+
+chai.config.includeStack = true;
+
+const TEST_PORT = 0; // let the OS assign an available port
+
+describe('POP3 PROXY socket error handling', () => {
+    let server;
+
+    afterEach(done => {
+        if (server) {
+            return server.close(() => {
+                server = false;
+                done();
+            });
+        }
+        return done();
+    });
+
+    it('should survive a client reset while waiting for the PROXY header', done => {
+        let finished = false;
+
+        const onUncaught = err => {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            process.removeListener('uncaughtException', onUncaught);
+            done(new Error('unhandled socket error during PROXY window: ' + (err && err.message)));
+        };
+        process.prependOnceListener('uncaughtException', onUncaught);
+
+        server = new POP3Server({ useProxy: ['*'], logger: false });
+        server.on('error', () => {});
+
+        server.listen(TEST_PORT, '127.0.0.1', () => {
+            const port = server.server.address().port;
+            const client = net.connect(port, '127.0.0.1', () => {
+                client.on('error', () => {});
+                client.resetAndDestroy();
+            });
+
+            setTimeout(() => {
+                if (finished) {
+                    return;
+                }
+                finished = true;
+                process.removeListener('uncaughtException', onUncaught);
+                done();
+            }, 200);
+        });
+    });
+
+    it('should still parse a valid PROXY header and greet the client', done => {
+        let finished = false;
+
+        server = new POP3Server({ useProxy: ['*'], logger: false });
+        server.on('error', () => {});
+
+        server.listen(TEST_PORT, '127.0.0.1', () => {
+            const port = server.server.address().port;
+            const client = net.connect(port, '127.0.0.1', () => {
+                client.write('PROXY TCP4 203.0.113.7 10.0.0.1 51234 110\r\n');
+            });
+
+            let buf = '';
+            client.on('data', data => {
+                buf += data.toString();
+                if (finished || !/\+OK/.test(buf)) {
+                    return;
+                }
+                finished = true;
+                expect(buf).to.include('+OK');
+                client.end();
+                return done();
+            });
+
+            client.on('error', err => {
+                if (!finished) {
+                    finished = true;
+                    return done(err);
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

When the PROXY protocol is enabled (`imap.useProxy`), a client that drops the
connection while the server is still reading the PROXY header crashes the whole
process with an unhandled `ECONNRESET`. The PROXY header is read before
authentication, so any client that can reach a PROXY-fronted listener can
trigger it — an unauthenticated denial of service. Both the IMAP server
(`imap-core`) and the POP3 server are affected; they carry the same
`_handleProxy` implementation.

## Root cause

`_handleProxy` parses the PROXY header directly on the freshly accepted socket,
before the connection object (and its error handler) exists. While waiting for
the header it attaches only a `readable` listener:

```js
socket.on('readable', socketReader);
```

There is no `error` (nor `close`/`end`) handler on the socket during that
window, so a socket error emitted there has no listener and is thrown, taking
the process down.

Two ways to hit it:

1. **Reset while waiting for the header** — the client sends `RST` before/while
   the header arrives → `read ECONNRESET` with no listener.
2. **Malformed header, then reset** — a non-`PROXY` line makes the code write a
   diagnostic (`socket.end('* BAD …')` / `'-ERR …'`) and `return` without ever
   invoking the callback; writing to the already-broken socket produces a late
   `write ECONNRESET`/`EPIPE` *after* any naive single error handler would have
   been removed. 

## The fix

Port the guarded `_handleProxy` shape already used in
[`smtp-server`](https://github.com/nodemailer/smtp-server) 3.19.3 (bundled here
as a dependency) into both servers:

- Funnel every exit from the PROXY window through a single-fire `done()` gate.
- Attach `error` + `close` + `end` handlers while waiting, so reset, close, and
  half-close all resolve cleanly (half-close no longer lingers until the socket
  timeout either).
- On the failure path, attach a no-op `error` handler **before** removing our
  own, so a late in-flight error (e.g. the `EPIPE`/`ECONNRESET` from flushing
  the `* BAD`/`-ERR` diagnostic) cannot surface as an uncaughtException.
- Route the malformed-header rejection through `done(err)` as well.
- Both `net.createServer` callers now `return` on error instead of proceeding to
  `connect()` on a dead socket.

## Tests

New regression tests for both servers:

- `imap-core/test/proxy-socket-error-test.js` — reset during the header wait, a
  malformed header followed by a reset, and a valid header that still parses
  (the greeting reports the proxied address).
- `test/pop3-proxy-socket-error-test.js` — reset during the header wait, and a
  valid header that still greets.

They are verified to catch the regression: against the unfixed code the three
crash-survival tests fail with exactly `read ECONNRESET` (×2) and
`write ECONNRESET`; with the fix all pass. Full suite green (`imap`, `pop3`,
unit, `api`) and ESLint clean.

## Reproduce

```js
const net = require('net');
const { IMAPServer } = require('./imap-core/lib/imap-server');

const server = new IMAPServer({ useProxy: ['*'] });
server.on('error', () => {}); // server-level guard
server.listen(0, '127.0.0.1', () => {
    const port = server.server.address().port;
    const client = net.connect(port, '127.0.0.1', () => client.resetAndDestroy());
    client.on('error', () => {});
});
// before the fix: the process exits on an unhandled 'read ECONNRESET'
```

## Scope

- Changed: `imap-core/lib/imap-server.js`, `lib/pop3/server.js`.
- Added: the two test files above.
- Additive and backward-compatible; no API or configuration change.